### PR TITLE
Preventing large ints being converted to floats when decoding.

### DIFF
--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -137,7 +137,7 @@ class JWT
              */
             $max_int_length = strlen((string) PHP_INT_MAX) - 1;
             $json_without_bigints = preg_replace('/:\s*(\d{'.$max_int_length.',})/', ': "$1"', $input);
-            $obj = json_decode($json_without_bigints, true);
+            $obj = json_decode($json_without_bigints);
         }
 
         if (function_exists('json_last_error') && $errno = json_last_error()) {


### PR DESCRIPTION
Integers larger than PHP_INT_MAX are getting automatically converted into floats by the json_decode() call. This is a problem if those ints are intended to be used as entity IDs.

This fix automatically converts large integers in JSON into strings instead, using the JSON_BIGINT_AS_STRING option param for PHP versions that support it (>=5.4.0), or in older versions by preprocessing the JSON string with preg_replace() to add quote marks around any integers longer than strlen((string) PHP_INT_MAX) - 1.
