### PR TITLE
Make it easier to use JWT with OpenIdConnect.

### DIFF
--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -65,10 +65,12 @@ class JWT
             if (empty($header->alg)) {
                 throw new DomainException('Empty algorithm');
             }
-            if (is_array($key) && !isset($header->kid)) {
-		throw new DomainException('"kid" empty, unable to lookup correct key');
-	    } elseif(is_array($key) && isset($header->kid)) {
-		$key = $key[$header->kid];
+            if (is_array($key)) {
+                if(isset($header->kid)) {
+                    $key = $key[$header->kid];
+                } else {
+                    throw new DomainException('"kid" empty, unable to lookup correct key');
+                }
 	    }
             if (!JWT::verify("$headb64.$bodyb64", $sig, $key, $header->alg)) {
                 throw new UnexpectedValueException('Signature verification failed');
@@ -116,7 +118,7 @@ class JWT
      * @param string $msg    The message to sign
      * @param string|resource $key    The secret key
      * @param string $method The signing algorithm. Supported
-     *                       algorithms are 'HS256', 'HS384' and 'HS512'
+     *                       algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'
      *
      * @return string          An encrypted message
      * @throws DomainException Unsupported algorithm was specified

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -47,8 +47,8 @@ class JWTTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($decoded->message, 'abc');
 	}
 
-	function testRSEncodeDecode() {
-		$privKey = openssl_pkey_new(array('digest_alg' => 'sha256', 
+	function testRSEncodeDecode(){
+		$privKey = openssl_pkey_new(array('digest_alg' => 'sha256',
 			'private_key_bits' => 1024,
 			'private_key_type' => OPENSSL_KEYTYPE_RSA));
 		$msg = JWT::encode('abc',$privKey, 'RS256');
@@ -58,7 +58,7 @@ class JWTTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($decoded, 'abc');
 	}
 
-	function testKIDChooser() {
+	function testKIDChooser(){
 		$keys = array('1' => 'my_key', '2' => 'my_key2');
 		$msg = JWT::encode('abc', $keys['1'], 'HS256', '1');
 		$decoded = JWT::decode($msg, $keys, true);


### PR DESCRIPTION
Add a method to retrieve the header. OpenIdConnect tends to add a "kid" to the header that is used to determine which key to use for verification. Getting header information allows you to figure out which key to pass to "decode". Other possible ways to handle this, allow $key passed to decode to be an array of keys. For now, I thought we should just let people get to the header.

I'm not sure about the duplication of code and effort in decodeHeader and decode, but this is the simplest way to get the functionality without changing the basic workflow.

Sorry about the whitespace added, I can remove it if you like the idea otherwise.
