### PR TITLE
JSON payload decode as array

### DIFF
--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -28,8 +28,9 @@ class JWT
      * @param string      $jwt       The JWT
      * @param string|Array|null $key The secret key, or map of keys
      * @param bool        $verify    Don't skip verification process
+     * @param bool        $asArray   Return array instead of object
      *
-     * @return object      The JWT's payload as a PHP object
+     * @return object|array  The JWT's payload as a PHP object or array
      *
      * @throws DomainException              Algorithm was not provided
      * @throws UnexpectedValueException     Provided JWT was invalid
@@ -41,7 +42,7 @@ class JWT
      * @uses jsonDecode
      * @uses urlsafeB64Decode
      */
-    public static function decode($jwt, $key = null, $verify = true)
+    public static function decode($jwt, $key = null, $verify = true, $asArray = false)
     {
         $tks = explode('.', $jwt);
         if (count($tks) != 3) {
@@ -94,8 +95,8 @@ class JWT
                 throw new ExpiredException('Expired token');
             }
         }
-
-        return $payload;
+        // Wait till here to generate array so verification is not impacted
+        return !$asArray ? $payload : JWT::jsonDecode(JWT::urlsafeB64Decode($bodyb64),true);
     }
 
     /**
@@ -200,19 +201,20 @@ class JWT
     /**
      * Decode a JSON string into a PHP object.
      *
-     * @param string $input JSON string
+     * @param string $input    JSON string
+     * @param bool   $asArray  Return array instead of object
      *
-     * @return object          Object representation of JSON string
+     * @return object|array    Object or array representation of JSON string
      * @throws DomainException Provided string was invalid JSON
      */
-    public static function jsonDecode($input)
+    public static function jsonDecode($input, $asArray = false)
     {
         if (version_compare(PHP_VERSION, '5.4.0', '>=') && !(defined('JSON_C_VERSION') && PHP_INT_SIZE > 4)) {
             /** In PHP >=5.4.0, json_decode() accepts an options parameter, that allows you
              * to specify that large ints (like Steam Transaction IDs) should be treated as
              * strings, rather than the PHP default behaviour of converting them to floats.
              */
-            $obj = json_decode($input, false, 512, JSON_BIGINT_AS_STRING);
+            $obj = json_decode($input, $asArray, 512, JSON_BIGINT_AS_STRING);
         } else {
             /** Not all servers will support that, however, so for older versions we must
              * manually detect large ints in the JSON string and quote them (thus converting
@@ -220,7 +222,7 @@ class JWT
              */
             $max_int_length = strlen((string) PHP_INT_MAX) - 1;
             $json_without_bigints = preg_replace('/:\s*(-?\d{'.$max_int_length.',})/', ': "$1"', $input);
-            $obj = json_decode($json_without_bigints);
+            $obj = json_decode($json_without_bigints,$asArray);
         }
 
         if (function_exists('json_last_error') && $errno = json_last_error()) {

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ $decoded = JWT::decode($jwt, $key);
 print_r($decoded);
 
 /*
- NOTE: This will now be an object instead of an associative array. To get
- an associative array, you will need to cast it as such:
+ NOTE: This will be an object instead of an associative array. To get
+ an associative array, set the fourth parameter to decode() to true.
+ (The third parameter is the verify switch)
 */
 
-$decoded_array = (array) $decoded;
+$decoded_array = = JWT::decode($jwt, $key, true, true);
 
 ?>
 ```

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -116,4 +116,14 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $decoded = JWT::decode($msg, $keys, true);
         $this->assertEquals($decoded, 'abc');
     }
+    public function testValidTokenAsArray()
+    {
+        $payload = array(
+            "message" => "abc",
+            "scopes"  => array("view","vote"),
+            );
+        $encoded = JWT::encode($payload, 'my_key');
+        $decoded = JWT::decode($encoded, 'my_key',true,true);
+        $this->assertEquals($decoded['scopes'][1], 'vote');
+    }
 }


### PR DESCRIPTION
Added a fourth parameter to JWT:decode to specify that the payload be returned as an indexed array.  This takes care of problems with typecasting an object to an array if the object contains additional collections.

Includes test case and documentation update.