### PR TITLE
Allow users to lock their app into an algorithm.

### DIFF
--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -15,6 +15,8 @@
  */
 class JWT
 {
+    public static $only_method = 'HS256';
+    
     public static $methods = array(
         'HS256' => array('hash_hmac', 'SHA256'),
         'HS512' => array('hash_hmac', 'SHA512'),
@@ -173,6 +175,11 @@ class JWT
         if (empty(self::$methods[$method])) {
             throw new DomainException('Algorithm not supported');
         }
+        if (self::$only_method === null) {
+            throw new DomainException('Algorithm not specified');
+        } elseif ($method !== self::$only_method) {
+            throw new DomainException('Incorrect algorithm error');
+        }
         list($function, $algo) = self::$methods[$method];
         switch($function) {
             case 'openssl':
@@ -298,5 +305,23 @@ class JWT
             ? $messages[$errno]
             : 'Unknown JSON error: ' . $errno
         );
+    }
+    
+    /**
+     * Set the only allowed method for this server.
+     * 
+     * @ref https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+     * 
+     * @param string $method array index in self::$methods
+     * 
+     * @return boolean
+     */
+    public static function setOnlyAllowedMethod($method)
+    {
+        if (!empty(self::$methods[$method])) {
+            self::$only_method = $method;
+            return true;
+        }
+        return false;
     }
 }

--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -192,13 +192,13 @@ class JWT
             case 'hash_hmac':
             default:
                 $hash = hash_hmac($algo, $msg, $key, true);
-                $len = min(strlen($signature), strlen($hash));
+                $len = min(self::safeStrlen($signature), self::safeStrlen($hash));
 
                 $status = 0;
                 for ($i = 0; $i < $len; $i++) {
                     $status |= (ord($signature[$i]) ^ ord($hash[$i]));
                 }
-                $status |= (strlen($signature) ^ strlen($hash));
+                $status |= (self::safeStrlen($signature) ^ self::safeStrlen($hash));
 
                 return ($status === 0);
         }
@@ -307,6 +307,20 @@ class JWT
         );
     }
     
+    /**
+     * Get the number of bytes in cryptographic strings.
+     *
+     * @param string
+     * @return int
+     */
+    private static function safeStrlen($str)
+    {
+        if (function_exists('mb_strlen')) {
+            return mb_strlen($str, '8bit');
+        }
+        return strlen($str);
+    }
+
     /**
      * Set the only allowed method for this server.
      * 

--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -192,6 +192,9 @@ class JWT
             case 'hash_hmac':
             default:
                 $hash = hash_hmac($algo, $msg, $key, true);
+                if (function_exists('hash_equals')) {
+                    return hash_equals($signature, $hash);
+                }
                 $len = min(self::safeStrlen($signature), self::safeStrlen($hash));
 
                 $status = 0;

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ $token = array(
     "nbf" => 1357000000
 );
 
+/*
+ IMPORTANT
+ HS256 is actually the default, but you should set it explicitly
+ if you intend to use another strategy (e.g. RS256):
+*/
+JWT::setOnlyMethodAllowed('HS256');
+
 $jwt = JWT::encode($token, $key);
 $decoded = JWT::decode($jwt, $key);
 

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -102,6 +102,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $privKey = openssl_pkey_new(array('digest_alg' => 'sha256',
             'private_key_bits' => 1024,
             'private_key_type' => OPENSSL_KEYTYPE_RSA));
+        JWT::setOnlyAllowedMethod('RS256');
         $msg = JWT::encode('abc', $privKey, 'RS256');
         $pubKey = openssl_pkey_get_details($privKey);
         $pubKey = $pubKey['key'];
@@ -112,6 +113,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testKIDChooser()
     {
         $keys = array('1' => 'my_key', '2' => 'my_key2');
+        JWT::setOnlyAllowedMethod('HS256');
         $msg = JWT::encode('abc', $keys['1'], 'HS256', '1');
         $decoded = JWT::decode($msg, $keys, true);
         $this->assertEquals($decoded, 'abc');


### PR DESCRIPTION
In addition to allowing users to lock their JWT class into supporting exactly one specific method at runtime (i.e. when their configuration is loaded) with a sane default, I also locked things down a little bit.

First, http://php.net/manual/en/mbstring.overload.php `mbstring.func_overload` can lead to incorrect results from `strlen()` treating string as UTF-8 instead of binary, which can reduce the cost of brute force for an invalid authentication signature.

Second, if `hash_equals()` exists, use that instead of a PHP-land implementation.