### PR TITLE
Remove the useless target-dir setting from the composer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,5 @@
     "autoload": {
         "classmap": ["Authentication/", "Exceptions/"]
     },
-    "target-dir": "Firebase/PHP-JWT",
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
target-dir was meant to allow using the root of the package as a PSR-4 root and make composer prepend the target dir when installing to make it compatible with PSR-0, before PSR-4 was a reality.
This setting is deprecated in Composer in favor of using PSR-4, and it is not needed anyway when using the classmap autoloading.