### PR TITLE
Provide a leeway in verification of times to account for clock skew

### DIFF
--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -38,9 +38,11 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testExpiredToken()
     {
         $this->setExpectedException('ExpiredException');
+        $timeInPast = time() - JWT::LEEWAYTIME - 20;
         $payload = array(
             "message" => "abc",
-            "exp" => time() - 20); // time in the past
+            "exp" => $timeInPast // time in the past
+        );
         $encoded = JWT::encode($payload, 'my_key');
         JWT::decode($encoded, 'my_key', array('HS256'));
     }
@@ -48,9 +50,11 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testBeforeValidTokenWithNbf()
     {
         $this->setExpectedException('BeforeValidException');
+        $timeInFuture = time() + JWT::LEEWAYTIME + 20;
         $payload = array(
             "message" => "abc",
-            "nbf" => time() + 20); // time in the future
+            "nbf" => $timeInFuture // time in the future
+        );
         $encoded = JWT::encode($payload, 'my_key');
         JWT::decode($encoded, 'my_key', array('HS256'));
     }
@@ -58,9 +62,11 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testBeforeValidTokenWithIat()
     {
         $this->setExpectedException('BeforeValidException');
+        $timeInFuture = time() + JWT::LEEWAYTIME + 20;
         $payload = array(
             "message" => "abc",
-            "iat" => time() + 20); // time in the future
+            "iat" => $timeInFuture // time in the future
+        );
         $encoded = JWT::encode($payload, 'my_key');
         JWT::decode($encoded, 'my_key', array('HS256'));
     }


### PR DESCRIPTION
I noticed there was a minor difference on the server generationg the JWT and the server decoding it (on an openid connect project) and althoug the difference is within millisecs, very often the iat verification failed so I had to read up at the documentation and verify there is some recomendation  at least for the exp and the nbf. so I've considered adding a leeway time to all time verifications.

Sources: 
http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#nbfDef
http://openid.net/specs/openid-connect-core-1_0.html#IDToken