### PR TITLE
Provide a leeway in verification of times to account for clock skew

### DIFF
--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -17,9 +17,11 @@ class JWT
 {
 
     /**
-     * When cheking nbf, iat or expiration times, we want to provide some extra leeway time to account for clock skew.
+     * When checking nbf, iat or expiration times,
+     * we want to provide some extra leeway time to
+     * account for clock skew.
      */
-    const LEEWAYTIME = 60;
+    public static $leeway = 0;
 
     public static $supported_algs = array(
         'HS256' => array('hash_hmac', 'SHA256'),
@@ -86,7 +88,7 @@ class JWT
 
             // Check if the nbf if it is defined. This is the time that the
             // token can actually be used. If it's not yet that time, abort.
-            if (isset($payload->nbf) && $payload->nbf > (time() + self::LEEWAYTIME)) {
+            if (isset($payload->nbf) && $payload->nbf > (time() + self::$leeway)) {
                 throw new BeforeValidException(
                     'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->nbf)
                 );
@@ -95,14 +97,14 @@ class JWT
             // Check that this token has been created before 'now'. This prevents
             // using tokens that have been created for later use (and haven't
             // correctly used the nbf claim).
-            if (isset($payload->iat) && $payload->iat > (time() + self::LEEWAYTIME)) {
+            if (isset($payload->iat) && $payload->iat > (time() + self::$leeway)) {
                 throw new BeforeValidException(
                     'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->iat)
                 );
             }
 
             // Check if this token has expired.
-            if (isset($payload->exp) && (time() - self::LEEWAYTIME) >= $payload->exp) {
+            if (isset($payload->exp) && (time() - self::$leeway) >= $payload->exp) {
                 throw new ExpiredException('Expired token');
             }
         }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ print_r($decoded);
 
 $decoded_array = (array) $decoded;
 
+/**
+ * You can add a leeway to account for when there is a clock skew times between
+ * the signing and verifying servers. It is recomended this leeway should not
+ * be bigger than a few minutes.
+ * Source: http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#nbfDef
+ */
+
+JWT::$leeway = 60;
+$decoded = JWT::decode($jwt, $key, array('HS256'));
+
 ?>
 ```
 

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -120,6 +120,50 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($decoded->message, 'abc');
     }
 
+    public function testValidTokenWithNbfLeeway()
+    {
+        JWT::$leeway = 60;
+        $payload = array(
+            "message" => "abc",
+            "nbf"     => time() + 20); // not before in near (leeway) future
+        $encoded = JWT::encode($payload, 'my_key');
+        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $this->assertEquals($decoded->message, 'abc');
+    }
+
+    public function testInvalidTokenWithNbfLeeway()
+    {
+        JWT::$leeway = 60;
+        $payload = array(
+            "message" => "abc",
+            "nbf"     => time() + 65); // not before too far in future
+        $encoded = JWT::encode($payload, 'my_key');
+        $this->setExpectedException('BeforeValidException');
+        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+    }
+
+    public function testValidTokenWithIatLeeway()
+    {
+        JWT::$leeway = 60;
+        $payload = array(
+            "message" => "abc",
+            "iat"     => time() + 20); // issued in near (leeway) future
+        $encoded = JWT::encode($payload, 'my_key');
+        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $this->assertEquals($decoded->message, 'abc');
+    }
+
+    public function testInvalidTokenWithIatLeeway()
+    {
+        JWT::$leeway = 60;
+        $payload = array(
+            "message" => "abc",
+            "iat"     => time() + 65); // issued too far in future
+        $encoded = JWT::encode($payload, 'my_key');
+        $this->setExpectedException('BeforeValidException');
+        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+    }
+
     public function testInvalidToken()
     {
         $payload = array(

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -38,9 +38,11 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testExpiredToken()
     {
         $this->setExpectedException('ExpiredException');
+        $timeInPast = time() - JWT::LEEWAYTIME - 20;
         $payload = array(
             "message" => "abc",
-            "exp" => time() - 20); // time in the past
+            "exp" => $timeInPast // time in the past
+        );
         $encoded = JWT::encode($payload, 'my_key');
         JWT::decode($encoded, 'my_key', array('HS256'));
     }
@@ -48,9 +50,11 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testBeforeValidTokenWithNbf()
     {
         $this->setExpectedException('BeforeValidException');
+        $timeInFuture = time() + JWT::LEEWAYTIME + 20;
         $payload = array(
             "message" => "abc",
-            "nbf" => time() + 20); // time in the future
+            "nbf" => $timeInFuture // time in the future
+        );
         $encoded = JWT::encode($payload, 'my_key');
         JWT::decode($encoded, 'my_key', array('HS256'));
     }
@@ -58,9 +62,11 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testBeforeValidTokenWithIat()
     {
         $this->setExpectedException('BeforeValidException');
+        $timeInFuture = time() + JWT::LEEWAYTIME + 20;
         $payload = array(
             "message" => "abc",
-            "iat" => time() + 20); // time in the future
+            "iat" => $timeInFuture // time in the future
+        );
         $encoded = JWT::encode($payload, 'my_key');
         JWT::decode($encoded, 'my_key', array('HS256'));
     }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -38,7 +38,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testExpiredToken()
     {
         $this->setExpectedException('ExpiredException');
-        $timeInPast = time() - JWT::LEEWAYTIME - 20;
+        $timeInPast = time() - 20;
         $payload = array(
             "message" => "abc",
             "exp" => $timeInPast // time in the past
@@ -50,7 +50,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testBeforeValidTokenWithNbf()
     {
         $this->setExpectedException('BeforeValidException');
-        $timeInFuture = time() + JWT::LEEWAYTIME + 20;
+        $timeInFuture = time() + 20;
         $payload = array(
             "message" => "abc",
             "nbf" => $timeInFuture // time in the future
@@ -62,7 +62,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testBeforeValidTokenWithIat()
     {
         $this->setExpectedException('BeforeValidException');
-        $timeInFuture = time() + JWT::LEEWAYTIME + 20;
+        $timeInFuture = time() + 20;
         $payload = array(
             "message" => "abc",
             "iat" => $timeInFuture // time in the future
@@ -75,7 +75,30 @@ class JWTTest extends PHPUnit_Framework_TestCase
     {
         $payload = array(
             "message" => "abc",
-            "exp" => time() + 20); // time in the future
+            "exp" => time() + JWT::$leeway + 20); // time in the future
+        $encoded = JWT::encode($payload, 'my_key');
+        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $this->assertEquals($decoded->message, 'abc');
+    }
+
+    public function testValidTokenWithLeeway()
+    {
+        JWT::$leeway = 60;
+        $payload = array(
+            "message" => "abc",
+            "exp" => time() - 20); // time in the past
+        $encoded = JWT::encode($payload, 'my_key');
+        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $this->assertEquals($decoded->message, 'abc');
+    }
+
+    public function testExpiredTokenWithLeeway()
+    {
+        JWT::$leeway = 60;
+        $payload = array(
+            "message" => "abc",
+            "exp" => time() - 70); // time far in the past
+        $this->setExpectedException('ExpiredException');
         $encoded = JWT::encode($payload, 'my_key');
         $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -38,11 +38,9 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testExpiredToken()
     {
         $this->setExpectedException('ExpiredException');
-        $timeInPast = time() - 20;
         $payload = array(
             "message" => "abc",
-            "exp" => $timeInPast // time in the past
-        );
+            "exp" => time() - 20); // time in the past
         $encoded = JWT::encode($payload, 'my_key');
         JWT::decode($encoded, 'my_key', array('HS256'));
     }
@@ -50,11 +48,9 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testBeforeValidTokenWithNbf()
     {
         $this->setExpectedException('BeforeValidException');
-        $timeInFuture = time() + 20;
         $payload = array(
             "message" => "abc",
-            "nbf" => $timeInFuture // time in the future
-        );
+            "nbf" => time() + 20); // time in the future
         $encoded = JWT::encode($payload, 'my_key');
         JWT::decode($encoded, 'my_key', array('HS256'));
     }
@@ -62,11 +58,9 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testBeforeValidTokenWithIat()
     {
         $this->setExpectedException('BeforeValidException');
-        $timeInFuture = time() + 20;
         $payload = array(
             "message" => "abc",
-            "iat" => $timeInFuture // time in the future
-        );
+            "iat" => time() + 20); // time in the future
         $encoded = JWT::encode($payload, 'my_key');
         JWT::decode($encoded, 'my_key', array('HS256'));
     }


### PR DESCRIPTION
I noticed there was a minor difference on the server generationg the JWT and the server decoding it (on an openid connect project) and althoug the difference is within millisecs, very often the iat verification failed so I had to read up at the documentation and verify there is some recomendation at least for the exp and the nbf. so I've considered adding a leeway time to all time verifications.

Sources: 
http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#nbfDef
http://openid.net/specs/openid-connect-core-1_0.html#IDToken

