### PR TITLE
Allow using \ArrayAccess as $key in \JWT::decode

### DIFF
--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -73,7 +73,7 @@ class JWT
             if (!is_array($allowed_algs) || !in_array($header->alg, $allowed_algs)) {
                 throw new DomainException('Algorithm not allowed');
             }
-            if (is_array($key)) {
+            if (is_array($key) || $key instanceof \ArrayAccess) {
                 if (isset($header->kid)) {
                     $key = $key[$header->kid];
                 } else {

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -194,6 +194,14 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($decoded, 'abc');
     }
 
+    public function testArrayAccessKIDChooser()
+    {
+        $keys = new ArrayObject(array('1' => 'my_key', '2' => 'my_key2'));
+        $msg = JWT::encode('abc', $keys['1'], 'HS256', '1');
+        $decoded = JWT::decode($msg, $keys, array('HS256'));
+        $this->assertEquals($decoded, 'abc');
+    }
+
     public function testNoneAlgorithm()
     {
         $msg = JWT::encode('abc', 'my_key');


### PR DESCRIPTION
When using the library with a large number of keys (ie. user specific keys), having to load all available keys is not efficient. 

This change allows to pass an ArrayAccess instance to perform dynamic lookups of the requested key without having to load all available keys.

Let me know if I should amend anything.