### PR TITLE
Adding optional headers to send in JWT

### DIFF
--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -132,7 +132,7 @@ class JWT
             $header['kid'] = $keyId;
         }
         if ( isset($head) && is_array($head) ) {
-            $header = array_merge($header, $head);
+            $header = array_merge($head, $header);
         }
         $segments = array();
         $segments[] = JWT::urlsafeB64Encode(JWT::jsonEncode($header));

--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -119,16 +119,20 @@ class JWT
      * @param string       $key     The secret key
      * @param string       $alg     The signing algorithm. Supported
      *                              algorithms are 'HS256', 'HS384' and 'HS512'
+     * @param array        $head    An array with header elements to attach
      *
      * @return string      A signed JWT
      * @uses jsonEncode
      * @uses urlsafeB64Encode
      */
-    public static function encode($payload, $key, $alg = 'HS256', $keyId = null)
+    public static function encode($payload, $key, $alg = 'HS256', $keyId = null, $head = null)
     {
         $header = array('typ' => 'JWT', 'alg' => $alg);
         if ($keyId !== null) {
             $header['kid'] = $keyId;
+        }
+        if ( isset($head) && is_array($head) ) {
+            array_push($header, $head);
         }
         $segments = array();
         $segments[] = JWT::urlsafeB64Encode(JWT::jsonEncode($header));

--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -132,7 +132,7 @@ class JWT
             $header['kid'] = $keyId;
         }
         if ( isset($head) && is_array($head) ) {
-            array_merge($header, $head);
+            $header = array_merge($header, $head);
         }
         $segments = array();
         $segments[] = JWT::urlsafeB64Encode(JWT::jsonEncode($header));

--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -132,7 +132,7 @@ class JWT
             $header['kid'] = $keyId;
         }
         if ( isset($head) && is_array($head) ) {
-            array_push($header, $head);
+            array_push($header, array_values($head));
         }
         $segments = array();
         $segments[] = JWT::urlsafeB64Encode(JWT::jsonEncode($header));

--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -132,7 +132,7 @@ class JWT
             $header['kid'] = $keyId;
         }
         if ( isset($head) && is_array($head) ) {
-            array_push($header, array_values($head));
+            array_merge($header, $head);
         }
         $segments = array();
         $segments[] = JWT::urlsafeB64Encode(JWT::jsonEncode($header));

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -228,4 +228,10 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException('DomainException');
         JWT::decode($msg, 'my_key');
     }
+
+    public function testAdditionalHeaders()
+    {
+        $msg = JWT::encode('abc', 'my_key', 'HS256', null, array('cty' => 'test-eit;v=1'));
+        $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');        
+    }
 }


### PR DESCRIPTION
Some services require additional info to be sent in the JOSE header, adding the option for encoding.