### PR TITLE
jsonEncode() now returns instance of ArrayObject instead of StdClass.

### DIFF
--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -250,6 +250,10 @@ class JWT
         } elseif ($obj === null && $input !== 'null') {
             throw new DomainException('Null result with non-null input');
         }
+
+        if ($obj instanceof StdClass) {
+            return new ArrayObject($obj, ArrayObject::ARRAY_AS_PROPS);
+        }
         return $obj;
     }
 

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -232,6 +232,15 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testAdditionalHeaders()
     {
         $msg = JWT::encode('abc', 'my_key', 'HS256', null, array('cty' => 'test-eit;v=1'));
-        $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');        
+        $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');
+    }
+
+    public function testJsonDecode()
+    {
+        $data = JWT::jsonDecode('{"foo": "bar"}');
+        $this->assertEquals('bar', $data->foo);
+        $this->assertEquals('bar', $data['foo']);
+
+        $this->assertEquals('abc', JWT::jsonDecode(json_encode('abc')));
     }
 }


### PR DESCRIPTION
Refs #30.

This should make everyone happy.