### PR TITLE
Consistency for encode/decode behavior.

### DIFF
--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -142,6 +142,9 @@ class JWT
         if ($keyId !== null) {
             $header['kid'] = $keyId;
         }
+        if ( isset($head) && is_array($head) ) {
+            $header = array_merge($head, $header);
+        }
         $segments = array();
         $segments[] = JWT::urlsafeB64Encode(JWT::jsonEncode($header));
         $segments[] = JWT::urlsafeB64Encode(JWT::jsonEncode($payload));

--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -79,7 +79,7 @@ class JWT
 
             //Default the allowed algorithms to decode's default value.
             if (empty($allowed_algs)) {
-                $allowed_algs = [self::DEFAULT_ALGORITHM];
+                $allowed_algs = array(self::DEFAULT_ALGORITHM);
             } elseif (!is_array($allowed_algs) || !in_array($header->alg, $allowed_algs)) {
                 throw new DomainException('Algorithm not allowed');
             }

--- a/Authentication/JWT.php
+++ b/Authentication/JWT.php
@@ -16,6 +16,12 @@
 class JWT
 {
 
+    const DEFAULT_ALGORITHM = 'HS256';
+    const HS256 = 'HS256';
+    const HS512 = 'HS512';
+    const HS384 = 'HS384';
+    const RS256 = 'RS256';
+
     /**
      * When checking nbf, iat or expiration times,
      * we want to provide some extra leeway time to
@@ -24,10 +30,10 @@ class JWT
     public static $leeway = 0;
 
     public static $supported_algs = array(
-        'HS256' => array('hash_hmac', 'SHA256'),
-        'HS512' => array('hash_hmac', 'SHA512'),
-        'HS384' => array('hash_hmac', 'SHA384'),
-        'RS256' => array('openssl', 'SHA256'),
+        self::HS256 => array('hash_hmac', 'SHA256'),
+        self::HS512 => array('hash_hmac', 'SHA512'),
+        self::HS384 => array('hash_hmac', 'SHA384'),
+        self::RS256 => array('openssl', 'SHA256')
     );
 
     /**
@@ -35,7 +41,7 @@ class JWT
      *
      * @param string      $jwt           The JWT
      * @param string|Array|null $key     The secret key, or map of keys
-     * @param Array       $allowed_algs  List of supported verification algorithms
+     * @param Array       $allowed_algs  List of supported verification algorithms. Defaults to HS256.
      *
      * @return object      The JWT's payload as a PHP object
      *
@@ -70,7 +76,11 @@ class JWT
             if (empty(self::$supported_algs[$header->alg])) {
                 throw new DomainException('Algorithm not supported');
             }
-            if (!is_array($allowed_algs) || !in_array($header->alg, $allowed_algs)) {
+
+            //Default the allowed algorithms to decode's default value.
+            if (empty($allowed_algs)) {
+                $allowed_algs = [self::DEFAULT_ALGORITHM];
+            } elseif (!is_array($allowed_algs) || !in_array($header->alg, $allowed_algs)) {
                 throw new DomainException('Algorithm not allowed');
             }
             if (is_array($key) || $key instanceof \ArrayAccess) {
@@ -118,21 +128,19 @@ class JWT
      * @param object|array $payload PHP object or array
      * @param string       $key     The secret key
      * @param string       $alg     The signing algorithm. Supported
-     *                              algorithms are 'HS256', 'HS384' and 'HS512'
+     *                              algorithms are 'HS256', 'HS384' and 'HS512'.
+     *                              Defaults to HS256.
      * @param array        $head    An array with header elements to attach
      *
      * @return string      A signed JWT
      * @uses jsonEncode
      * @uses urlsafeB64Encode
      */
-    public static function encode($payload, $key, $alg = 'HS256', $keyId = null, $head = null)
+    public static function encode($payload, $key, $alg = self::DEFAULT_ALGORITHM, $keyId = null, $head = null)
     {
         $header = array('typ' => 'JWT', 'alg' => $alg);
         if ($keyId !== null) {
             $header['kid'] = $keyId;
-        }
-        if ( isset($head) && is_array($head) ) {
-            $header = array_merge($head, $header);
         }
         $segments = array();
         $segments[] = JWT::urlsafeB64Encode(JWT::jsonEncode($header));
@@ -156,7 +164,7 @@ class JWT
      * @return string          An encrypted message
      * @throws DomainException Unsupported algorithm was specified
      */
-    public static function sign($msg, $key, $alg = 'HS256')
+    public static function sign($msg, $key, $alg = self::DEFAULT_ALGORITHM)
     {
         if (empty(self::$supported_algs[$alg])) {
             throw new DomainException('Algorithm not supported');

--- a/README.md
+++ b/README.md
@@ -32,12 +32,15 @@ $token = array(
 
 /**
  * IMPORTANT:
- * You must specify supported algorithms for your application. See
+ * Both operations will default to HS256 if no algorithm is specified
+ * as third optional parameter e.g. `array(JWT::HS256)`.
+ * See :
  * https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40
  * for a list of spec-compliant algorithms.
- */
+ **/
+
 $jwt = JWT::encode($token, $key);
-$decoded = JWT::decode($jwt, $key, array('HS256'));
+$decoded = JWT::decode($jwt, $key);
 
 print_r($decoded);
 
@@ -56,7 +59,7 @@ $decoded_array = (array) $decoded;
  * Source: http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#nbfDef
  */
 JWT::$leeway = 60; // $leeway in seconds
-$decoded = JWT::decode($jwt, $key, array('HS256'));
+$decoded = JWT::decode($jwt, $key);
 
 ?>
 ```

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -4,9 +4,16 @@ class JWTTest extends PHPUnit_Framework_TestCase
 {
     public function testEncodeDecode()
     {
+        //Defaults
         $msg = JWT::encode('abc', 'my_key');
-        $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');
+        $this->assertEquals(JWT::decode($msg, 'my_key'), 'abc');
+
+        //Custom
+        $msg = JWT::encode('abc', 'my_key', Jwt::HS512);
+        $this->assertEquals(JWT::decode($msg, 'my_key', [Jwt::HS512]), 'abc');
     }
+
+
 
     public function testDecodeFromPython()
     {
@@ -222,16 +229,16 @@ class JWTTest extends PHPUnit_Framework_TestCase
         JWT::decode($msg, 'my_key', array('RS256'));
     }
 
-    public function testMissingAlgorithm()
+    public function testMatchingAlgorithm()
     {
         $msg = JWT::encode('abc', 'my_key');
         $this->setExpectedException('DomainException');
-        JWT::decode($msg, 'my_key');
+        JWT::decode($msg, 'my_key', [JWT::HS512]);
     }
 
     public function testAdditionalHeaders()
     {
         $msg = JWT::encode('abc', 'my_key', 'HS256', null, array('cty' => 'test-eit;v=1'));
-        $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');        
+        $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');
     }
 }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -10,7 +10,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
         //Custom
         $msg = JWT::encode('abc', 'my_key', Jwt::HS512);
-        $this->assertEquals(JWT::decode($msg, 'my_key', [Jwt::HS512]), 'abc');
+        $this->assertEquals(JWT::decode($msg, 'my_key', array(Jwt::HS512)), 'abc');
     }
 
 
@@ -233,7 +233,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
     {
         $msg = JWT::encode('abc', 'my_key');
         $this->setExpectedException('DomainException');
-        JWT::decode($msg, 'my_key', [JWT::HS512]);
+        JWT::decode($msg, 'my_key', array(JWT::HS512));
     }
 
     public function testAdditionalHeaders()


### PR DESCRIPTION
Hey there,

Directly PR-in as it's a minor thing. I'm not a fan of encode/decode having different behavior - One defaulting to HS256 and the other throwing an exception. This is a minor change that makes both default to the same algorithm and I const-ed the available algorithms as QoL for foreign code.
Apologies for not discussing first, let me know if it's an issue.