### PR TITLE
Add firebase\jwt namespace

### DIFF
--- a/Exceptions/BeforeValidException.php
+++ b/Exceptions/BeforeValidException.php
@@ -1,6 +1,0 @@
-<?php
-
-class BeforeValidException extends UnexpectedValueException
-{
-
-}

--- a/Exceptions/ExpiredException.php
+++ b/Exceptions/ExpiredException.php
@@ -1,6 +1,0 @@
-<?php
-
-class ExpiredException extends UnexpectedValueException
-{
-
-}

--- a/Exceptions/SignatureInvalidException.php
+++ b/Exceptions/SignatureInvalidException.php
@@ -1,6 +1,0 @@
-<?php
-
-class SignatureInvalidException extends UnexpectedValueException
-{
-
-}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Example
 -------
 ```php
 <?php
+use \Firebase\JWT\JWT;
 
 $key = "example_key";
 $token = array(

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,12 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.2.0"
+        "php": ">=5.3.0"
     },
     "autoload": {
-        "classmap": ["Authentication/", "Exceptions/"]
+        "psr-4": {
+            "Firebase\\JWT\\": "src"
+        }
     },
     "minimum-stability": "dev"
 }

--- a/src/BeforeValidException.php
+++ b/src/BeforeValidException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Firebase\JWT;
+
+class BeforeValidException extends \UnexpectedValueException
+{
+
+}

--- a/src/ExpiredException.php
+++ b/src/ExpiredException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Firebase\JWT;
+
+class ExpiredException extends \UnexpectedValueException
+{
+
+}

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -2,6 +2,7 @@
 
 namespace Firebase\JWT;
 use \DomainException;
+use \UnexpectedValueException;
 use \DateTime;
 
 /**

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace Firebase\JWT;
+use \DomainException;
+use \DateTime;
+
 /**
  * JSON Web Token implementation, based on this spec:
  * http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06

--- a/src/SignatureInvalidException.php
+++ b/src/SignatureInvalidException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Firebase\JWT;
+
+class SignatureInvalidException extends \UnexpectedValueException
+{
+
+}

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -1,4 +1,5 @@
 <?php
+use \Firebase\JWT\JWT;
 
 class JWTTest extends PHPUnit_Framework_TestCase
 {
@@ -37,7 +38,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testExpiredToken()
     {
-        $this->setExpectedException('ExpiredException');
+        $this->setExpectedException('Firebase\JWT\ExpiredException');
         $payload = array(
             "message" => "abc",
             "exp" => time() - 20); // time in the past
@@ -47,7 +48,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testBeforeValidTokenWithNbf()
     {
-        $this->setExpectedException('BeforeValidException');
+        $this->setExpectedException('Firebase\JWT\BeforeValidException');
         $payload = array(
             "message" => "abc",
             "nbf" => time() + 20); // time in the future
@@ -57,7 +58,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testBeforeValidTokenWithIat()
     {
-        $this->setExpectedException('BeforeValidException');
+        $this->setExpectedException('Firebase\JWT\BeforeValidException');
         $payload = array(
             "message" => "abc",
             "iat" => time() + 20); // time in the future
@@ -93,7 +94,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $payload = array(
             "message" => "abc",
             "exp" => time() - 70); // time far in the past
-        $this->setExpectedException('ExpiredException');
+        $this->setExpectedException('Firebase\JWT\ExpiredException');
         $encoded = JWT::encode($payload, 'my_key');
         $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');
@@ -141,7 +142,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
             "message" => "abc",
             "nbf"     => time() + 65); // not before too far in future
         $encoded = JWT::encode($payload, 'my_key');
-        $this->setExpectedException('BeforeValidException');
+        $this->setExpectedException('Firebase\JWT\BeforeValidException');
         $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
         JWT::$leeway = 0;
     }
@@ -165,7 +166,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
             "message" => "abc",
             "iat"     => time() + 65); // issued too far in future
         $encoded = JWT::encode($payload, 'my_key');
-        $this->setExpectedException('BeforeValidException');
+        $this->setExpectedException('Firebase\JWT\BeforeValidException');
         $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
         JWT::$leeway = 0;
     }
@@ -176,7 +177,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
             "message" => "abc",
             "exp" => time() + 20); // time in the future
         $encoded = JWT::encode($payload, 'my_key');
-        $this->setExpectedException('SignatureInvalidException');
+        $this->setExpectedException('Firebase\JWT\SignatureInvalidException');
         $decoded = JWT::decode($encoded, 'my_key2', array('HS256'));
     }
 

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -235,4 +235,10 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $msg = JWT::encode('abc', 'my_key', 'HS256', null, array('cty' => 'test-eit;v=1'));
         $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');        
     }
+
+    public function testInvalidSegmentCount()
+    {
+        $this->setExpectedException('UnexpectedValueException');
+        JWT::decode('brokenheader.brokenbody', 'my_key', array('HS256'));
+    }
 }


### PR DESCRIPTION
Puts the jwt class under the `\Firebase\JWT` namespace.

There is more discussion here: https://github.com/firebase/php-jwt/issues/52
I chose this namespace scheme to match another firebase php library: https://github.com/firebase/firebase-token-generator-php/tree/master/src