### PR TITLE
require a non-empty key to decode a JWT

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -2,6 +2,7 @@
 
 namespace Firebase\JWT;
 use \DomainException;
+use \InvalidArgumentException;
 use \UnexpectedValueException;
 use \DateTime;
 

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -180,6 +180,26 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $decoded = JWT::decode($encoded, 'my_key2', array('HS256'));
     }
 
+    public function testNullKeyFails()
+    {
+        $payload = array(
+            "message" => "abc",
+            "exp" => time() + JWT::$leeway + 20); // time in the future
+        $encoded = JWT::encode($payload, 'my_key');
+        $this->setExpectedException('InvalidArgumentException');
+        $decoded = JWT::decode($encoded, null, array('HS256'));
+    }
+
+    public function testEmptyKeyFails()
+    {
+        $payload = array(
+            "message" => "abc",
+            "exp" => time() + JWT::$leeway + 20); // time in the future
+        $encoded = JWT::encode($payload, 'my_key');
+        $this->setExpectedException('InvalidArgumentException');
+        $decoded = JWT::decode($encoded, '', array('HS256'));
+    }
+
     public function testRSEncodeDecode()
     {
         $privKey = openssl_pkey_new(array('digest_alg' => 'sha256',


### PR DESCRIPTION
In testing this library for use on a project, I was surprised when JWT::decode returned a successfully decoded payload even when an empty key was supplied.  I mistakenly supplied an empty key b/c I accidentally referred to it in a config file by the wrong name.

I would think that an empty key should be an error.  Otherwise, it would be possible to deploy an application using this library and have all tokens be successfully decoded, regardless of what key was used to encode them.  As mentioned above, this could happen through accidental mishandling of configuration files.

I could be wrong about this and an empty key might be possible by design.  If so, nevermind, and I'll just be more careful. ;-)

I've made the code changes to JWT::decode and added 2 new tests to verify that empty keys generate exceptions. 