### PR TITLE
support for plain text JWT

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -28,11 +28,17 @@ class JWT
      */
     public static $leeway = 0;
 
+    /**
+     * An associative array with the keys being the supported algorithms.
+     * The values are mappings to input data for creating the signature.
+     * @var array
+     */
     public static $supported_algs = array(
         'HS256' => array('hash_hmac', 'SHA256'),
         'HS512' => array('hash_hmac', 'SHA512'),
         'HS384' => array('hash_hmac', 'SHA384'),
         'RS256' => array('openssl', 'SHA256'),
+        'none'  => array(null, null),
     );
 
     /**
@@ -168,6 +174,8 @@ class JWT
         }
         list($function, $algorithm) = self::$supported_algs[$alg];
         switch($function) {
+            case 'none' :
+                return '';
             case 'hash_hmac':
                 return hash_hmac($algorithm, $msg, $key, true);
             case 'openssl':
@@ -199,6 +207,10 @@ class JWT
 
         list($function, $algorithm) = self::$supported_algs[$alg];
         switch($function) {
+            case 'none' :
+                return true;
+                break;
+
             case 'openssl':
                 $success = openssl_verify($msg, $signature, $key, $algorithm);
                 if (!$success) {

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -241,4 +241,35 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException('UnexpectedValueException');
         JWT::decode('brokenheader.brokenbody', 'my_key', array('HS256'));
     }
+    
+     /**
+     * Encodes and decodes a plain text JWT
+     * @link https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06#section-6
+     */
+    public function testPlainTextJWTEncodeDecode()
+    {
+        $msg = JWT::encode('abc', null, 'none');
+        $this->assertEquals(JWT::decode($msg, null), 'abc');
+    }
+
+    /**
+     * Checks the encoding format (output) of a plain text JWT
+     * @link https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06#section-6
+     */
+    public function testPlainTextJWTEncodingFormat()
+    {
+        $msg = JWT::encode('abc', null, 'none');
+        $this->assertEquals('eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.ImFiYyI.', $msg, 'signature should be empty after second . seperator');
+    }
+
+    /**
+     * Checks that using a secret key has no impact for the plain text JWT
+     * @link https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06#section-6
+     */
+    public function testPlainTextJWTEncodeWithNonUsedKeyDecode()
+    {
+        $msg = JWT::encode('abc', 'foo', 'none');
+        $this->assertEquals(JWT::decode($msg), 'abc');
+    }
+
 }


### PR DESCRIPTION
support added according to the JWT specification at https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06#section-6 for non-encrypted and unsigned JWT using TLS