### PR TITLE
Remove null as possible key value in docblock

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -39,11 +39,11 @@ class JWT
     /**
      * Decodes a JWT string into a PHP object.
      *
-     * @param string            $jwt            The JWT
-     * @param string|array|null $key            The key, or map of keys.
-     *                                          If the algorithm used is asymmetric, this is the public key
-     * @param array             $allowed_algs   List of supported verification algorithms
-     *                                          Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'
+     * @param string        $jwt            The JWT
+     * @param string|array  $key            The key, or map of keys.
+     *                                      If the algorithm used is asymmetric, this is the public key
+     * @param array         $allowed_algs   List of supported verification algorithms
+     *                                      Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'
      *
      * @return object The JWT's payload as a PHP object
      *


### PR DESCRIPTION
The docblock states that null is a possible value for $key, however, it clearly results in an exception.