### PR TITLE
hash_equals ErrorException Patch

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -221,6 +221,7 @@ class JWT
             default:
                 $hash = hash_hmac($algorithm, $msg, $key, true);
                 if (function_exists('hash_equals')) {
+                    error_reporting(E_ALL & ~E_WARNING);
                     return hash_equals($signature, $hash);
                 }
                 $len = min(self::safeStrlen($signature), self::safeStrlen($hash));


### PR DESCRIPTION
hash_equals throws ErrorException when error level use E_WARNING
