### PR TITLE
Fix exceptions classes

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -78,19 +78,19 @@ class JWT
         $sig = JWT::urlsafeB64Decode($cryptob64);
         
         if (empty($header->alg)) {
-            throw new DomainException('Empty algorithm');
+            throw new UnexpectedValueException('Empty algorithm');
         }
         if (empty(self::$supported_algs[$header->alg])) {
-            throw new DomainException('Algorithm not supported');
+            throw new UnexpectedValueException('Algorithm not supported');
         }
         if (!in_array($header->alg, $allowed_algs)) {
-            throw new DomainException('Algorithm not allowed');
+            throw new UnexpectedValueException('Algorithm not allowed');
         }
         if (is_array($key) || $key instanceof \ArrayAccess) {
             if (isset($header->kid)) {
                 $key = $key[$header->kid];
             } else {
-                throw new DomainException('"kid" empty, unable to lookup correct key');
+                throw new UnexpectedValueException('"kid" empty, unable to lookup correct key');
             }
         }
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -47,7 +47,6 @@ class JWT
      *
      * @return object The JWT's payload as a PHP object
      *
-     * @throws DomainException              Algorithm was not provided
      * @throws UnexpectedValueException     Provided JWT was invalid
      * @throws SignatureInvalidException    Provided JWT was invalid because the signature verification failed
      * @throws BeforeValidException         Provided JWT is trying to be used before it's eligible as defined by 'nbf'
@@ -61,6 +60,9 @@ class JWT
     {
         if (empty($key)) {
             throw new InvalidArgumentException('Key may not be empty');
+        }
+        if (!is_array($allowed_algs)) {
+            throw new InvalidArgumentException('Algorithm not allowed');
         }
         $tks = explode('.', $jwt);
         if (count($tks) != 3) {
@@ -81,7 +83,7 @@ class JWT
         if (empty(self::$supported_algs[$header->alg])) {
             throw new DomainException('Algorithm not supported');
         }
-        if (!is_array($allowed_algs) || !in_array($header->alg, $allowed_algs)) {
+        if (!in_array($header->alg, $allowed_algs)) {
             throw new DomainException('Algorithm not allowed');
         }
         if (is_array($key) || $key instanceof \ArrayAccess) {

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -232,21 +232,21 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testNoneAlgorithm()
     {
         $msg = JWT::encode('abc', 'my_key');
-        $this->setExpectedException('DomainException');
+        $this->setExpectedException('UnexpectedValueException');
         JWT::decode($msg, 'my_key', array('none'));
     }
 
     public function testIncorrectAlgorithm()
     {
         $msg = JWT::encode('abc', 'my_key');
-        $this->setExpectedException('DomainException');
+        $this->setExpectedException('UnexpectedValueException');
         JWT::decode($msg, 'my_key', array('RS256'));
     }
 
     public function testMissingAlgorithm()
     {
         $msg = JWT::encode('abc', 'my_key');
-        $this->setExpectedException('DomainException');
+        $this->setExpectedException('UnexpectedValueException');
         JWT::decode($msg, 'my_key');
     }
 


### PR DESCRIPTION
**Use InvalidArgumentException when $allowed_algs is not array**

> Exception thrown if an argument is not of the expected type.
http://php.net/manual/en/class.invalidargumentexception.php

**Use RuntimeExceptions for exceptions related with unencoded data.**

RuntimeExceptions is the correct exception error source is the decoded data.

Note LogicExceptions as defined in PHP documentation implies a modification in the code by the developer.

> Exception that represents error in the program logic. This kind of exception should lead directly to a fix in your code.
http://php.net/manual/en/class.logicexception.php

But the token is a data provided by an external source which is out side of the control of the developer so there is no way of prevent malformed tokens.


```
try {} catch (\Exception) {} // Incorrect

try {} catch (\RuntimeException) {} // Correct
```
