### PR TITLE
Remove newline at beginning of run-tests.sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 gpg --fingerprint D8406D0D82947747293778314AA394086372C20A
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
The extra newline trips a warning in lintian when packaging for Debian,
so just remove it.