### PR TITLE
Detect invalid Base64 encoding in signature

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -85,8 +85,10 @@ class JWT
         if (null === $payload = static::jsonDecode(static::urlsafeB64Decode($bodyb64))) {
             throw new UnexpectedValueException('Invalid claims encoding');
         }
-        $sig = static::urlsafeB64Decode($cryptob64);
-        
+        if (false === ($sig = static::urlsafeB64Decode($cryptob64))) {
+            throw new UnexpectedValueException('Invalid signature encoding');
+        }
+
         if (empty($header->alg)) {
             throw new UnexpectedValueException('Empty algorithm');
         }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -261,4 +261,11 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException('UnexpectedValueException');
         JWT::decode('brokenheader.brokenbody', 'my_key', array('HS256'));
     }
+
+    public function testInvalidSignatureEncoding()
+    {
+        $msg = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwibmFtZSI6ImZvbyJ9.Q4Kee9E8o0Xfo4ADXvYA8t7dN_X_bU9K5w6tXuiSjlUxx";
+        $this->setExpectedException('UnexpectedValueException');
+        JWT::decode($msg, 'secret', array('HS256'));
+    }
 }


### PR DESCRIPTION
Identifies invalid Base64 encoding (`base64_decode` return `false` if the input data is an invalid Base64 string), and throws an exception. Addresses #102.
