### PR TITLE
Add the proper Exception message for all JSON error types by PHP

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -339,14 +339,14 @@ class JWT
      *
      * @return void
      */
-    private static function ($errno)
+    private static function handleJsonError($errno)
     {
         $messages = array(
             JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
             JSON_ERROR_STATE_MISMATCH => 'Invalid or malformed JSON',
             JSON_ERROR_CTRL_CHAR => 'Unexpected control character found',
             JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON',
-            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters', //PHP >= 5.3.3
+            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters' //PHP >= 5.3.3
         );
         throw new DomainException(
             isset($messages[$errno])

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -339,7 +339,7 @@ class JWT
      *
      * @return void
      */
-    private static function handleJsonError($errno)
+    private static function ($errno)
     {
         $messages = array(
             JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
@@ -347,9 +347,6 @@ class JWT
             JSON_ERROR_CTRL_CHAR => 'Unexpected control character found',
             JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON',
             JSON_ERROR_UTF8 => 'Malformed UTF-8 characters', //PHP >= 5.3.3
-            JSON_ERROR_RECURSION => 'One or more recursive references in the value to be encoded', //PHP >= 5.5.0
-            JSON_ERROR_INF_OR_NAN => 'One or more NAN or INF values in the value to be encoded', //PHP >= 5.5.0
-            JSON_ERROR_UNSUPPORTED_TYPE => 'A value of a type that cannot be encoded was given' //PHP >= 5.5.0
         );
         throw new DomainException(
             isset($messages[$errno])

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -86,7 +86,7 @@ class JWT
             throw new UnexpectedValueException('Invalid claims encoding');
         }
         $sig = static::urlsafeB64Decode($cryptob64);
-        
+
         if (empty($header->alg)) {
             throw new UnexpectedValueException('Empty algorithm');
         }
@@ -343,8 +343,13 @@ class JWT
     {
         $messages = array(
             JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
+            JSON_ERROR_STATE_MISMATCH => 'Invalid or malformed JSON',
             JSON_ERROR_CTRL_CHAR => 'Unexpected control character found',
-            JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON'
+            JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON',
+            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters', //PHP >= 5.3.3
+            JSON_ERROR_RECURSION => 'One or more recursive references in the value to be encoded', //PHP >= 5.5.0
+            JSON_ERROR_INF_OR_NAN => 'One or more NAN or INF values in the value to be encoded', //PHP >= 5.5.0
+            JSON_ERROR_UNSUPPORTED_TYPE => 'A value of a type that cannot be encoded was given' //PHP >= 5.5.0
         );
         throw new DomainException(
             isset($messages[$errno])


### PR DESCRIPTION
Related to issue #99 Unknown JSON error

[`json_last_error_msg()`](http://php.net/manual/en/function.json-last-error-msg.php) is not used because it would break compatibility with PHP < 5.5. 
This solution supports all error types until 5.5, keeping compatibility with previous versions.
