### PR TITLE
Add new line warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Time: 0 seconds, Memory: 2.50Mb
 OK (5 tests, 5 assertions)
 ```
 
+New Lines in private keys
+-----
+
+If your private key contains `\n` characters, be sure to wrap it in double quotes `""`
+and not single quotes `''` in order to properly interpret the escaped characters.
+
 License
 -------
 [3-Clause BSD](http://opensource.org/licenses/BSD-3-Clause).


### PR DESCRIPTION
Quickly addresses #109, but a better solution would be to warn the user if they're using `RSA` and we don't see any new lines in their private key.
