### PR TITLE
Support RS384 and RS512

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -42,6 +42,8 @@ class JWT
         'HS512' => array('hash_hmac', 'SHA512'),
         'HS384' => array('hash_hmac', 'SHA384'),
         'RS256' => array('openssl', 'SHA256'),
+        'RS384' => array('openssl', 'SHA384'),
+        'RS512' => array('openssl', 'SHA512'),
     );
 
     /**


### PR DESCRIPTION
No backward compatibility breaks, just add support for RS384 and RS512 algorithms.

This should help tick more boxes on jwt.io

I've just signed the CLA
