### PR TITLE
openssl_sign arg 4 needs OPENSSL_ALGO_SHA1

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -41,7 +41,7 @@ class JWT
         'HS256' => array('hash_hmac', 'SHA256'),
         'HS512' => array('hash_hmac', 'SHA512'),
         'HS384' => array('hash_hmac', 'SHA384'),
-        'RS256' => array('openssl', 'SHA256'),
+        'RS256' => array('openssl', OPENSSL_ALGO_SHA1),
     );
 
     /**


### PR DESCRIPTION
Replace string 'SHA256' with integer const `OPENSSL_ALGO_SHA1` in the table of `supported_algs`.
see http://php.net/manual/en/function.openssl-sign.php

Fix this error:
```
PHP Warning:  openssl_sign() expects parameter 4 to be long, string given in /tmp/jwt/Authentication/JWT.php on line 170
PHP Fatal error:  Uncaught exception 'DomainException' with message 'OpenSSL unable to sign data' in /tmp/jwt/Authentication/JWT.php:172
Stack trace:
#0 /tmp/jwt/Authentication/JWT.php(142): JWT::sign('eyJ0eXAiOiJKV1Q...', false, 'RS256')
#1 /tmp/jwt-test-openssl.php(14): JWT::encode(Array, false, 'RS256')
#2 {main}
  thrown in /tmp/jwt/Authentication/JWT.php on line 172
```
Test example:

```
<?php
use \Firebase\JWT\JWT;

$publicKey  = file_get_contents('pubkey.pem');
$privateKey = file_get_contents('privkey.pem');

$token = array(
    "iss" => "http://example.org",
    "aud" => "http://example.com",
    "iat" => 1356999524,
    "nbf" => 1357000000
);

$jwt = JWT::encode($token, $privateKey, 'RS256');
$decoded = JWT::decode($jwt, $publicKey, array('RS256'));

print_r($decoded);
?>
```

Edit: This error exists on PHP 5.2.6 only. So, this issue is for php-jwt version 2.2.0 only.
