### PR TITLE
Add JSON_NUMERIC_CHECK as default json_encode option for JWT payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Example
 -------
 ```php
 <?php
-use \Firebase\JWT\JWT;
+use \Dremie\JWT\JWT;
 
 $key = "example_key";
 $token = array(

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php": ">=5.3.0"
     },
     "autoload": {
-        "psr-4": {
-            "Dremie\\JWT\\": "src"
+        "psr-0": {
+            "Dremie\\JWT\\": "src/"
         }
     },
     "minimum-stability": "dev"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "autoload": {
         "psr-0": {
             "Dremie\\JWT\\": "src/"
-        }
+        },
+        "classmap": ["src/"]
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "firebase/php-jwt",
+    "name": "dremie/php-jwt",
     "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
-    "homepage": "https://github.com/firebase/php-jwt",
+    "homepage": "https://github.com/dremie/php-jwt",
     "authors": [
         {
             "name": "Neuman Vong",
@@ -20,7 +20,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Firebase\\JWT\\": "src"
+            "Dremie\\JWT\\": "src"
         }
     },
     "minimum-stability": "dev"

--- a/src/BeforeValidException.php
+++ b/src/BeforeValidException.php
@@ -1,5 +1,5 @@
 <?php
-namespace Firebase\JWT;
+namespace Dremie\JWT;
 
 class BeforeValidException extends \UnexpectedValueException
 {

--- a/src/ExpiredException.php
+++ b/src/ExpiredException.php
@@ -1,5 +1,5 @@
 <?php
-namespace Firebase\JWT;
+namespace Dremie\JWT;
 
 class ExpiredException extends \UnexpectedValueException
 {

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Firebase\JWT;
+namespace Dremie\JWT;
 use \DomainException;
 use \InvalidArgumentException;
 use \UnexpectedValueException;

--- a/src/SignatureInvalidException.php
+++ b/src/SignatureInvalidException.php
@@ -1,5 +1,5 @@
 <?php
-namespace Firebase\JWT;
+namespace Dremie\JWT;
 
 class SignatureInvalidException extends \UnexpectedValueException
 {

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -1,5 +1,5 @@
 <?php
-use \Firebase\JWT\JWT;
+use \Dremie\JWT\JWT;
 
 class JWTTest extends PHPUnit_Framework_TestCase
 {
@@ -38,7 +38,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testExpiredToken()
     {
-        $this->setExpectedException('Firebase\JWT\ExpiredException');
+        $this->setExpectedException('Dremie\JWT\ExpiredException');
         $payload = array(
             "message" => "abc",
             "exp" => time() - 20); // time in the past
@@ -48,7 +48,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testBeforeValidTokenWithNbf()
     {
-        $this->setExpectedException('Firebase\JWT\BeforeValidException');
+        $this->setExpectedException('Dremie\JWT\BeforeValidException');
         $payload = array(
             "message" => "abc",
             "nbf" => time() + 20); // time in the future
@@ -58,7 +58,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testBeforeValidTokenWithIat()
     {
-        $this->setExpectedException('Firebase\JWT\BeforeValidException');
+        $this->setExpectedException('Dremie\JWT\BeforeValidException');
         $payload = array(
             "message" => "abc",
             "iat" => time() + 20); // time in the future
@@ -94,7 +94,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $payload = array(
             "message" => "abc",
             "exp" => time() - 70); // time far in the past
-        $this->setExpectedException('Firebase\JWT\ExpiredException');
+        $this->setExpectedException('Dremie\JWT\ExpiredException');
         $encoded = JWT::encode($payload, 'my_key');
         $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');
@@ -142,7 +142,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
             "message" => "abc",
             "nbf"     => time() + 65); // not before too far in future
         $encoded = JWT::encode($payload, 'my_key');
-        $this->setExpectedException('Firebase\JWT\BeforeValidException');
+        $this->setExpectedException('Dremie\JWT\BeforeValidException');
         $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
         JWT::$leeway = 0;
     }
@@ -166,7 +166,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
             "message" => "abc",
             "iat"     => time() + 65); // issued too far in future
         $encoded = JWT::encode($payload, 'my_key');
-        $this->setExpectedException('Firebase\JWT\BeforeValidException');
+        $this->setExpectedException('Dremie\JWT\BeforeValidException');
         $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
         JWT::$leeway = 0;
     }
@@ -177,7 +177,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
             "message" => "abc",
             "exp" => time() + 20); // time in the future
         $encoded = JWT::encode($payload, 'my_key');
-        $this->setExpectedException('Firebase\JWT\SignatureInvalidException');
+        $this->setExpectedException('Dremie\JWT\SignatureInvalidException');
         $decoded = JWT::decode($encoded, 'my_key2', array('HS256'));
     }
 


### PR DESCRIPTION
Does what the title suggests.

Use case: 
1. In a server-side PHP application, load data from a database, with at least one column having an integer
data type
2. Encode these data as payload in JWT
3. Send (return) to a client written in JavaScript
4. Perform arithmetic / strict equality checks on the integer data field without having to do typecasting or conceding to non-strict equality checks. 

I'm not aware of any adverse effects.