### PR TITLE
bugfix: 'kid' not in given key list

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -98,8 +98,8 @@ class JWT
         }
         if (is_array($key) || $key instanceof \ArrayAccess) {
             if (isset($header->kid)) {
-                if(!isset($key[$header->kid])) {
-                    throw new UnexpectedValueException('"kid" not found in key map, unable to lookup correct key');
+                if (!isset($key[$header->kid])) {
+                    throw new UnexpectedValueException('"kid" invalid, unable to lookup correct key');
                 }
                 $key = $key[$header->kid];
             } else {

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -98,6 +98,9 @@ class JWT
         }
         if (is_array($key) || $key instanceof \ArrayAccess) {
             if (isset($header->kid)) {
+                if(!isset($key[$header->kid])) {
+                    throw new UnexpectedValueException('"kid" not found in key map, unable to lookup correct key');
+                }
                 $key = $key[$header->kid];
             } else {
                 throw new UnexpectedValueException('"kid" empty, unable to lookup correct key');


### PR DESCRIPTION
if 'kid' value is not found in the given key map, should throw an exception.
Instead, it was outputting a php warning for using an undefined index, resulting in a null key.