### PR TITLE
Fix warning when signature is invalid

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -234,7 +234,7 @@ class JWT
             default:
                 $hash = hash_hmac($algorithm, $msg, $key, true);
                 if (function_exists('hash_equals')) {
-                    return hash_equals($signature, $hash);
+                    return hash_equals((string)$signature, $hash);
                 }
                 $len = min(static::safeStrlen($signature), static::safeStrlen($hash));
 


### PR DESCRIPTION
Had error : hash_equals(): Expected known_string to be a string, boolean given