### PR TITLE
Adding the payload in the exceptions

### DIFF
--- a/src/BeforeValidException.php
+++ b/src/BeforeValidException.php
@@ -5,7 +5,8 @@ class BeforeValidException extends \UnexpectedValueException
 {
 	private $payload;
 	
-	public function setPayload($payload){
+	public function __construct($payload, $message, $code = 0, $cause = null){
+		parent::__construct($message, $code, $cause);
 		$this->payload = $payload;
 	}
 	

--- a/src/BeforeValidException.php
+++ b/src/BeforeValidException.php
@@ -4,9 +4,11 @@ namespace Firebase\JWT;
 class BeforeValidException extends \UnexpectedValueException
 {
 	private $payload;
-	public function __construct($payload = null){
+	
+	public function setPayload($payload){
 		$this->payload = $payload;
 	}
+	
 	public function getPayload(){
 		return $this->payload;
 	}

--- a/src/BeforeValidException.php
+++ b/src/BeforeValidException.php
@@ -3,5 +3,11 @@ namespace Firebase\JWT;
 
 class BeforeValidException extends \UnexpectedValueException
 {
-
+	private $payload;
+	public function __construct($payload = null){
+		$this->payload = $payload;
+	}
+	public function getPayload(){
+		return $this->payload;
+	}
 }

--- a/src/BeforeValidException.php
+++ b/src/BeforeValidException.php
@@ -5,8 +5,8 @@ class BeforeValidException extends \UnexpectedValueException
 {
 	private $payload;
 	
-	public function __construct($payload, $message, $code = 0, $cause = null){
-		parent::__construct($message, $code, $cause);
+	public function __construct($payload, $message, $code = 0, $previous = null){
+		parent::__construct($message, $code, $previous);
 		$this->payload = $payload;
 	}
 	

--- a/src/ExpiredException.php
+++ b/src/ExpiredException.php
@@ -4,11 +4,12 @@ namespace Firebase\JWT;
 class ExpiredException extends \UnexpectedValueException
 {
 	private $payload;
-
-	public function setPayload($payload){
+	
+	public function __construct($payload, $message, $code = 0, $cause = null){
+		parent::__construct($message, $code, $cause);
 		$this->payload = $payload;
 	}
-
+	
 	public function getPayload(){
 		return $this->payload;
 	}

--- a/src/ExpiredException.php
+++ b/src/ExpiredException.php
@@ -3,5 +3,13 @@ namespace Firebase\JWT;
 
 class ExpiredException extends \UnexpectedValueException
 {
+	private $payload;
 
+	public function __construct($payload = null){
+		$this->payload = $payload;
+	}
+
+	public function getPayload(){
+		return $this->payload;
+	}
 }

--- a/src/ExpiredException.php
+++ b/src/ExpiredException.php
@@ -5,8 +5,8 @@ class ExpiredException extends \UnexpectedValueException
 {
 	private $payload;
 	
-	public function __construct($payload, $message, $code = 0, $cause = null){
-		parent::__construct($message, $code, $cause);
+	public function __construct($payload, $message, $code = 0, $previous = null){
+		parent::__construct($message, $code, $previous);
 		$this->payload = $payload;
 	}
 	

--- a/src/ExpiredException.php
+++ b/src/ExpiredException.php
@@ -5,7 +5,7 @@ class ExpiredException extends \UnexpectedValueException
 {
 	private $payload;
 
-	public function __construct($payload = null){
+	public function setPayload($payload){
 		$this->payload = $payload;
 	}
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -106,13 +106,14 @@ class JWT
 
         // Check the signature
         if (!static::verify("$headb64.$bodyb64", $sig, $key, $header->alg)) {
-            throw new SignatureInvalidException('Signature verification failed');
+            throw new SignatureInvalidException($payload, 'Signature verification failed');
         }
 
         // Check if the nbf if it is defined. This is the time that the
         // token can actually be used. If it's not yet that time, abort.
         if (isset($payload->nbf) && $payload->nbf > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
+                $payload,
                 'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->nbf)
             );
         }
@@ -122,13 +123,14 @@ class JWT
         // correctly used the nbf claim).
         if (isset($payload->iat) && $payload->iat > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
+                $payload, 
                 'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->iat)
             );
         }
 
         // Check if this token has expired.
         if (isset($payload->exp) && ($timestamp - static::$leeway) >= $payload->exp) {
-            throw new ExpiredException('Expired token');
+            throw new ExpiredException($payload, 'Expired token');
         }
 
         return $payload;

--- a/src/SignatureInvalidException.php
+++ b/src/SignatureInvalidException.php
@@ -5,8 +5,8 @@ class SignatureInvalidException extends \UnexpectedValueException
 {  
 	private $payload;
 	
-	public function __construct($payload, $message, $code = 0, $cause = null){
-		parent::__construct($message, $code, $cause);
+	public function __construct($payload, $message, $code = 0, $previous = null){
+		parent::__construct($message, $code, $previous);
 		$this->payload = $payload;
 	}
 	

--- a/src/SignatureInvalidException.php
+++ b/src/SignatureInvalidException.php
@@ -3,5 +3,14 @@ namespace Firebase\JWT;
 
 class SignatureInvalidException extends \UnexpectedValueException
 {
-
+  
+	private $payload;
+  
+	public function setPayload($payload){
+		$this->payload = $payload;
+	}
+  
+	public function getPayload(){
+		return $this->payload;
+	}
 }

--- a/src/SignatureInvalidException.php
+++ b/src/SignatureInvalidException.php
@@ -4,11 +4,12 @@ namespace Firebase\JWT;
 class SignatureInvalidException extends \UnexpectedValueException
 {  
 	private $payload;
-  
-	public function setPayload($payload){
+	
+	public function __construct($payload, $message, $code = 0, $cause = null){
+		parent::__construct($message, $code, $cause);
 		$this->payload = $payload;
 	}
-  
+	
 	public function getPayload(){
 		return $this->payload;
 	}

--- a/src/SignatureInvalidException.php
+++ b/src/SignatureInvalidException.php
@@ -2,8 +2,7 @@
 namespace Firebase\JWT;
 
 class SignatureInvalidException extends \UnexpectedValueException
-{
-  
+{  
 	private $payload;
   
 	public function setPayload($payload){


### PR DESCRIPTION
Hi,
I added the payload in the custom exceptions SignatureInvalidException, BeforeValidException and ExpiredException. This may be useful if we need to inspect the payload even if the token is somehow invalid. 

Example: in a form to reset the password, if the token is expired, you can ask the user to resend the email with a new token, but to do so you need to access the user ID in the token.