### PR TITLE
ignore json_encode error

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -294,7 +294,7 @@ class JWT
      */
     public static function jsonEncode($input)
     {
-        $json = json_encode($input);
+        $json = @json_encode($input);
         if (function_exists('json_last_error') && $errno = json_last_error()) {
             static::handleJsonError($errno);
         } elseif ($json === 'null' && $input !== null) {


### PR DESCRIPTION
On of test case raise an error and not complete test.
```
$ phpunit --configuration ./phpunit.xml.dist
PHPUnit 4.8.35 by Sebastian Bergmann and contributors.

...E........................

Time: 417 ms, Memory: 26.25MB

There was 1 error:

1) JWTTest::testMalformedUtf8StringsFail
json_encode(): Invalid UTF-8 sequence in argument

/opt/tmp/src/JWT.php:297
/opt/tmp/src/JWT.php:164
/opt/tmp/tests/JWTTest.php:30

FAILURES!
Tests: 28, Assertions: 27, Errors: 1.
```

This error is raised on `json_encode` function. but the error is handled much good. 
https://github.com/firebase/php-jwt/blob/master/src/JWT.php#L297
I think you can ignore that error.So I ignored the error.
