### PR TITLE
Detect invalid Base64 encoding in signature

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -87,8 +87,9 @@ class JWT
         if (null === $payload = static::jsonDecode(static::urlsafeB64Decode($bodyb64))) {
             throw new UnexpectedValueException('Invalid claims encoding');
         }
-        $sig = static::urlsafeB64Decode($cryptob64);
-
+        if (false === ($sig = static::urlsafeB64Decode($cryptob64))) {
+            throw new UnexpectedValueException('Invalid signature encoding');
+        }
         if (empty($header->alg)) {
             throw new UnexpectedValueException('Empty algorithm');
         }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -267,6 +267,13 @@ class JWTTest extends PHPUnit_Framework_TestCase
         JWT::decode('brokenheader.brokenbody', 'my_key', array('HS256'));
     }
 
+    public function testInvalidSignatureEncoding()
+    {
+        $msg = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwibmFtZSI6ImZvbyJ9.Q4Kee9E8o0Xfo4ADXvYA8t7dN_X_bU9K5w6tXuiSjlUxx";
+        $this->setExpectedException('UnexpectedValueException');
+        JWT::decode($msg, 'secret', array('HS256'));
+    }
+
     public function testVerifyError()
     {
         $this->setExpectedException('DomainException');


### PR DESCRIPTION
Updated version of #103