### PR TITLE
UPDATED jwt.php

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -107,11 +107,6 @@ class JWT
             }
         }
 
-        // Check the signature
-        if (!static::verify("$headb64.$bodyb64", $sig, $key, $header->alg)) {
-            throw new SignatureInvalidException('Signature verification failed');
-        }
-
         // Check if the nbf if it is defined. This is the time that the
         // token can actually be used. If it's not yet that time, abort.
         if (isset($payload->nbf) && $payload->nbf > ($timestamp + static::$leeway)) {
@@ -132,6 +127,11 @@ class JWT
         // Check if this token has expired.
         if (isset($payload->exp) && ($timestamp - static::$leeway) >= $payload->exp) {
             throw new ExpiredException('Expired token');
+        }
+        
+        // Check the signature
+        if (!static::verify("$headb64.$bodyb64", $sig, $key, $header->alg)) {
+            throw new SignatureInvalidException('Signature verification failed');
         }
 
         return $payload;


### PR DESCRIPTION
Hello,

If you use the JWT to verify a token (expired, can't be used yet, etc) it is impossible becuase signature verification happens before that. In my specific case, I use a fake secret "tmpSecret" and then run decode to see if it is expired, etc. But I found out that it doesn't work correctly because signature verification is before the time checks. I only moved the line of signature verification before the return at the end of the decode function.

Also, this is my first pull request so if I did something wrong, please let me know.