### PR TITLE
Custom exception FormatInvalidException

### DIFF
--- a/src/BeforeValidException.php
+++ b/src/BeforeValidException.php
@@ -1,7 +1,7 @@
 <?php
 namespace Firebase\JWT;
 
-class BeforeValidException extends \UnexpectedValueException
+class BeforeValidException extends JWTException
 {
 
 }

--- a/src/ExpiredException.php
+++ b/src/ExpiredException.php
@@ -1,7 +1,7 @@
 <?php
 namespace Firebase\JWT;
 
-class ExpiredException extends \UnexpectedValueException
+class ExpiredException extends JWTException
 {
 
 }

--- a/src/FormatInvalidException.php
+++ b/src/FormatInvalidException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Firebase\JWT;
+
+class FormatInvalidException extends \UnexpectedValueException
+{
+
+}

--- a/src/FormatInvalidException.php
+++ b/src/FormatInvalidException.php
@@ -1,7 +1,7 @@
 <?php
 namespace Firebase\JWT;
 
-class FormatInvalidException extends \UnexpectedValueException
+class FormatInvalidException extends JWTException
 {
 
 }

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -58,6 +58,7 @@ class JWT
      * @return object The JWT's payload as a PHP object
      *
      * @throws UnexpectedValueException     Provided JWT was invalid
+     * @throws FormatInvalidException       Provided JWT has invalid format
      * @throws SignatureInvalidException    Provided JWT was invalid because the signature verification failed
      * @throws BeforeValidException         Provided JWT is trying to be used before it's eligible as defined by 'nbf'
      * @throws BeforeValidException         Provided JWT is trying to be used before it's been created as defined by 'iat'
@@ -75,35 +76,35 @@ class JWT
         }
         $tks = explode('.', $jwt);
         if (count($tks) != 3) {
-            throw new UnexpectedValueException('Wrong number of segments');
+            throw new FormatInvalidException('Wrong number of segments');
         }
         list($headb64, $bodyb64, $cryptob64) = $tks;
         if (null === ($header = static::jsonDecode(static::urlsafeB64Decode($headb64)))) {
-            throw new UnexpectedValueException('Invalid header encoding');
+            throw new FormatInvalidException('Invalid header encoding');
         }
         if (null === $payload = static::jsonDecode(static::urlsafeB64Decode($bodyb64))) {
-            throw new UnexpectedValueException('Invalid claims encoding');
+            throw new FormatInvalidException('Invalid claims encoding');
         }
         if (false === ($sig = static::urlsafeB64Decode($cryptob64))) {
             throw new UnexpectedValueException('Invalid signature encoding');
         }
         if (empty($header->alg)) {
-            throw new UnexpectedValueException('Empty algorithm');
+            throw new FormatInvalidException('Empty algorithm');
         }
         if (empty(static::$supported_algs[$header->alg])) {
-            throw new UnexpectedValueException('Algorithm not supported');
+            throw new FormatInvalidException('Algorithm not supported');
         }
         if (!in_array($header->alg, $allowed_algs)) {
-            throw new UnexpectedValueException('Algorithm not allowed');
+            throw new FormatInvalidException('Algorithm not allowed');
         }
         if (is_array($key) || $key instanceof \ArrayAccess) {
             if (isset($header->kid)) {
                 if (!isset($key[$header->kid])) {
-                    throw new UnexpectedValueException('"kid" invalid, unable to lookup correct key');
+                    throw new FormatInvalidException('"kid" invalid, unable to lookup correct key');
                 }
                 $key = $key[$header->kid];
             } else {
-                throw new UnexpectedValueException('"kid" empty, unable to lookup correct key');
+                throw new FormatInvalidException('"kid" empty, unable to lookup correct key');
             }
         }
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -2,7 +2,6 @@
 
 namespace Firebase\JWT;
 use \DomainException;
-use \InvalidArgumentException;
 use \DateTime;
 
 /**
@@ -70,7 +69,7 @@ class JWT
         $timestamp = is_null(static::$timestamp) ? time() : static::$timestamp;
 
         if (empty($key)) {
-            throw new InvalidArgumentException('Key may not be empty');
+            throw new KeyEmptyException('Key may not be empty');
         }
         $tks = explode('.', $jwt);
         if (count($tks) != 3) {

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -3,7 +3,6 @@
 namespace Firebase\JWT;
 use \DomainException;
 use \InvalidArgumentException;
-use \UnexpectedValueException;
 use \DateTime;
 
 /**
@@ -57,7 +56,6 @@ class JWT
      *
      * @return object The JWT's payload as a PHP object
      *
-     * @throws UnexpectedValueException     Provided JWT was invalid
      * @throws FormatInvalidException       Provided JWT has invalid format
      * @throws SignatureInvalidException    Provided JWT was invalid because the signature verification failed
      * @throws BeforeValidException         Provided JWT is trying to be used before it's eligible as defined by 'nbf'
@@ -86,7 +84,7 @@ class JWT
             throw new FormatInvalidException('Invalid claims encoding');
         }
         if (false === ($sig = static::urlsafeB64Decode($cryptob64))) {
-            throw new UnexpectedValueException('Invalid signature encoding');
+            throw new SignatureInvalidException('Invalid signature encoding');
         }
         if (empty($header->alg)) {
             throw new FormatInvalidException('Empty algorithm');

--- a/src/JWTException.php
+++ b/src/JWTException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Firebase\JWT;
+
+class JWTException extends \UnexpectedValueException
+{
+
+}

--- a/src/KeyEmptyException.php
+++ b/src/KeyEmptyException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Firebase\JWT;
+
+class KeyEmptyException extends \UnexpectedValueException
+{
+
+}

--- a/src/KeyEmptyException.php
+++ b/src/KeyEmptyException.php
@@ -1,7 +1,7 @@
 <?php
 namespace Firebase\JWT;
 
-class KeyEmptyException extends \UnexpectedValueException
+class KeyEmptyException extends JWTException
 {
 
 }

--- a/src/SignatureInvalidException.php
+++ b/src/SignatureInvalidException.php
@@ -1,7 +1,7 @@
 <?php
 namespace Firebase\JWT;
 
-class SignatureInvalidException extends \UnexpectedValueException
+class SignatureInvalidException extends JWTException
 {
 
 }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -270,7 +270,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testInvalidSignatureEncoding()
     {
         $msg = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwibmFtZSI6ImZvbyJ9.Q4Kee9E8o0Xfo4ADXvYA8t7dN_X_bU9K5w6tXuiSjlUxx";
-        $this->setExpectedException('UnexpectedValueException');
+        $this->setExpectedException('Firebase\JWT\SignatureInvalidException');
         JWT::decode($msg, 'secret', array('HS256'));
     }
 

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -237,21 +237,21 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testNoneAlgorithm()
     {
         $msg = JWT::encode('abc', 'my_key');
-        $this->setExpectedException('UnexpectedValueException');
+        $this->setExpectedException('Firebase\JWT\FormatInvalidException');
         JWT::decode($msg, 'my_key', array('none'));
     }
 
     public function testIncorrectAlgorithm()
     {
         $msg = JWT::encode('abc', 'my_key');
-        $this->setExpectedException('UnexpectedValueException');
+        $this->setExpectedException('Firebase\JWT\FormatInvalidException');
         JWT::decode($msg, 'my_key', array('RS256'));
     }
 
     public function testMissingAlgorithm()
     {
         $msg = JWT::encode('abc', 'my_key');
-        $this->setExpectedException('UnexpectedValueException');
+        $this->setExpectedException('Firebase\JWT\FormatInvalidException');
         JWT::decode($msg, 'my_key');
     }
 
@@ -263,7 +263,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testInvalidSegmentCount()
     {
-        $this->setExpectedException('UnexpectedValueException');
+        $this->setExpectedException('Firebase\JWT\FormatInvalidException');
         JWT::decode('brokenheader.brokenbody', 'my_key', array('HS256'));
     }
 

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -192,7 +192,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
             "message" => "abc",
             "exp" => time() + JWT::$leeway + 20); // time in the future
         $encoded = JWT::encode($payload, 'my_key');
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException('Firebase\JWT\KeyEmptyException');
         $decoded = JWT::decode($encoded, null, array('HS256'));
     }
 
@@ -202,7 +202,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
             "message" => "abc",
             "exp" => time() + JWT::$leeway + 20); // time in the future
         $encoded = JWT::encode($payload, 'my_key');
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException('Firebase\JWT\KeyEmptyException');
         $decoded = JWT::decode($encoded, '', array('HS256'));
     }
 


### PR DESCRIPTION
This PR solves the problem of distinguishing JWT related exceptions from the same standard `UnexpectedValueException` exceptions from other packages.

#176 