### PR TITLE
Avoid static processing

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -90,7 +90,7 @@ class JWT
         if (empty($header->alg)) {
             throw new UnexpectedValueException('Empty algorithm');
         }
-        if (empty(self::$supported_algs[$header->alg])) {
+        if (empty(static::$supported_algs[$header->alg])) {
             throw new UnexpectedValueException('Algorithm not supported');
         }
         if (!in_array($header->alg, $allowed_algs)) {
@@ -187,10 +187,10 @@ class JWT
      */
     public function sign($msg, $key, $alg = 'HS256')
     {
-        if (empty(self::$supported_algs[$alg])) {
+        if (empty(static::$supported_algs[$alg])) {
             throw new DomainException('Algorithm not supported');
         }
-        list($function, $algorithm) = self::$supported_algs[$alg];
+        list($function, $algorithm) = static::$supported_algs[$alg];
         switch($function) {
             case 'hash_hmac':
                 return hash_hmac($algorithm, $msg, $key, true);
@@ -220,11 +220,11 @@ class JWT
      */
     private function verify($msg, $signature, $key, $alg)
     {
-        if (empty(self::$supported_algs[$alg])) {
+        if (empty(static::$supported_algs[$alg])) {
             throw new DomainException('Algorithm not supported');
         }
 
-        list($function, $algorithm) = self::$supported_algs[$alg];
+        list($function, $algorithm) = static::$supported_algs[$alg];
         switch($function) {
             case 'openssl':
                 $success = openssl_verify($msg, $signature, $key, $algorithm);

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -27,7 +27,7 @@ class JWT
      * we want to provide some extra leeway time to
      * account for clock skew.
      */
-    public static $leeway = 0;
+    public $leeway = 0;
 
     /**
      * Allow the current timestamp to be specified.
@@ -35,7 +35,7 @@ class JWT
      *
      * Will default to PHP time() value if null.
      */
-    public static $timestamp = null;
+    public $timestamp = null;
 
     public static $supported_algs = array(
         'HS256' => array('hash_hmac', 'SHA256'),
@@ -66,9 +66,9 @@ class JWT
      * @uses jsonDecode
      * @uses urlsafeB64Decode
      */
-    public static function decode($jwt, $key, array $allowed_algs = array())
+    public function decode($jwt, $key, array $allowed_algs = array())
     {
-        $timestamp = is_null(static::$timestamp) ? time() : static::$timestamp;
+        $timestamp = is_null($this->timestamp) ? time() : $this->timestamp;
 
         if (empty($key)) {
             throw new InvalidArgumentException('Key may not be empty');
@@ -78,19 +78,19 @@ class JWT
             throw new UnexpectedValueException('Wrong number of segments');
         }
         list($headb64, $bodyb64, $cryptob64) = $tks;
-        if (null === ($header = static::jsonDecode(static::urlsafeB64Decode($headb64)))) {
+        if (null === ($header = $this->jsonDecode($this->urlsafeB64Decode($headb64)))) {
             throw new UnexpectedValueException('Invalid header encoding');
         }
-        if (null === $payload = static::jsonDecode(static::urlsafeB64Decode($bodyb64))) {
+        if (null === $payload = $this->jsonDecode($this->urlsafeB64Decode($bodyb64))) {
             throw new UnexpectedValueException('Invalid claims encoding');
         }
-        if (false === ($sig = static::urlsafeB64Decode($cryptob64))) {
+        if (false === ($sig = $this->urlsafeB64Decode($cryptob64))) {
             throw new UnexpectedValueException('Invalid signature encoding');
         }
         if (empty($header->alg)) {
             throw new UnexpectedValueException('Empty algorithm');
         }
-        if (empty(static::$supported_algs[$header->alg])) {
+        if (empty(self::$supported_algs[$header->alg])) {
             throw new UnexpectedValueException('Algorithm not supported');
         }
         if (!in_array($header->alg, $allowed_algs)) {
@@ -108,13 +108,13 @@ class JWT
         }
 
         // Check the signature
-        if (!static::verify("$headb64.$bodyb64", $sig, $key, $header->alg)) {
+        if (!$this->verify("$headb64.$bodyb64", $sig, $key, $header->alg)) {
             throw new SignatureInvalidException('Signature verification failed');
         }
 
         // Check if the nbf if it is defined. This is the time that the
         // token can actually be used. If it's not yet that time, abort.
-        if (isset($payload->nbf) && $payload->nbf > ($timestamp + static::$leeway)) {
+        if (isset($payload->nbf) && $payload->nbf > ($timestamp + $this->leeway)) {
             throw new BeforeValidException(
                 'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->nbf)
             );
@@ -123,14 +123,14 @@ class JWT
         // Check that this token has been created before 'now'. This prevents
         // using tokens that have been created for later use (and haven't
         // correctly used the nbf claim).
-        if (isset($payload->iat) && $payload->iat > ($timestamp + static::$leeway)) {
+        if (isset($payload->iat) && $payload->iat > ($timestamp + $this->leeway)) {
             throw new BeforeValidException(
                 'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->iat)
             );
         }
 
         // Check if this token has expired.
-        if (isset($payload->exp) && ($timestamp - static::$leeway) >= $payload->exp) {
+        if (isset($payload->exp) && ($timestamp - $this->leeway) >= $payload->exp) {
             throw new ExpiredException('Expired token');
         }
 
@@ -153,7 +153,7 @@ class JWT
      * @uses jsonEncode
      * @uses urlsafeB64Encode
      */
-    public static function encode($payload, $key, $alg = 'HS256', $keyId = null, $head = null)
+    public function encode($payload, $key, $alg = 'HS256', $keyId = null, $head = null)
     {
         $header = array('typ' => 'JWT', 'alg' => $alg);
         if ($keyId !== null) {
@@ -163,12 +163,12 @@ class JWT
             $header = array_merge($head, $header);
         }
         $segments = array();
-        $segments[] = static::urlsafeB64Encode(static::jsonEncode($header));
-        $segments[] = static::urlsafeB64Encode(static::jsonEncode($payload));
+        $segments[] = $this->urlsafeB64Encode($this->jsonEncode($header));
+        $segments[] = $this->urlsafeB64Encode($this->jsonEncode($payload));
         $signing_input = implode('.', $segments);
 
-        $signature = static::sign($signing_input, $key, $alg);
-        $segments[] = static::urlsafeB64Encode($signature);
+        $signature = $this->sign($signing_input, $key, $alg);
+        $segments[] = $this->urlsafeB64Encode($signature);
 
         return implode('.', $segments);
     }
@@ -185,12 +185,12 @@ class JWT
      *
      * @throws DomainException Unsupported algorithm was specified
      */
-    public static function sign($msg, $key, $alg = 'HS256')
+    public function sign($msg, $key, $alg = 'HS256')
     {
-        if (empty(static::$supported_algs[$alg])) {
+        if (empty(self::$supported_algs[$alg])) {
             throw new DomainException('Algorithm not supported');
         }
-        list($function, $algorithm) = static::$supported_algs[$alg];
+        list($function, $algorithm) = self::$supported_algs[$alg];
         switch($function) {
             case 'hash_hmac':
                 return hash_hmac($algorithm, $msg, $key, true);
@@ -218,13 +218,13 @@ class JWT
      *
      * @throws DomainException Invalid Algorithm or OpenSSL failure
      */
-    private static function verify($msg, $signature, $key, $alg)
+    private function verify($msg, $signature, $key, $alg)
     {
-        if (empty(static::$supported_algs[$alg])) {
+        if (empty(self::$supported_algs[$alg])) {
             throw new DomainException('Algorithm not supported');
         }
 
-        list($function, $algorithm) = static::$supported_algs[$alg];
+        list($function, $algorithm) = self::$supported_algs[$alg];
         switch($function) {
             case 'openssl':
                 $success = openssl_verify($msg, $signature, $key, $algorithm);
@@ -243,13 +243,13 @@ class JWT
                 if (function_exists('hash_equals')) {
                     return hash_equals($signature, $hash);
                 }
-                $len = min(static::safeStrlen($signature), static::safeStrlen($hash));
+                $len = min($this->safeStrlen($signature), $this->safeStrlen($hash));
 
                 $status = 0;
                 for ($i = 0; $i < $len; $i++) {
                     $status |= (ord($signature[$i]) ^ ord($hash[$i]));
                 }
-                $status |= (static::safeStrlen($signature) ^ static::safeStrlen($hash));
+                $status |= ($this->safeStrlen($signature) ^ $this->safeStrlen($hash));
 
                 return ($status === 0);
         }
@@ -264,7 +264,7 @@ class JWT
      *
      * @throws DomainException Provided string was invalid JSON
      */
-    public static function jsonDecode($input)
+    public function jsonDecode($input)
     {
         if (version_compare(PHP_VERSION, '5.4.0', '>=') && !(defined('JSON_C_VERSION') && PHP_INT_SIZE > 4)) {
             /** In PHP >=5.4.0, json_decode() accepts an options parameter, that allows you
@@ -283,7 +283,7 @@ class JWT
         }
 
         if (function_exists('json_last_error') && $errno = json_last_error()) {
-            static::handleJsonError($errno);
+            $this->handleJsonError($errno);
         } elseif ($obj === null && $input !== 'null') {
             throw new DomainException('Null result with non-null input');
         }
@@ -299,11 +299,11 @@ class JWT
      *
      * @throws DomainException Provided object could not be encoded to valid JSON
      */
-    public static function jsonEncode($input)
+    public function jsonEncode($input)
     {
         $json = json_encode($input);
         if (function_exists('json_last_error') && $errno = json_last_error()) {
-            static::handleJsonError($errno);
+            $this->handleJsonError($errno);
         } elseif ($json === 'null' && $input !== null) {
             throw new DomainException('Null result with non-null input');
         }
@@ -317,7 +317,7 @@ class JWT
      *
      * @return string A decoded string
      */
-    public static function urlsafeB64Decode($input)
+    public function urlsafeB64Decode($input)
     {
         $remainder = strlen($input) % 4;
         if ($remainder) {
@@ -334,7 +334,7 @@ class JWT
      *
      * @return string The base64 encode of what you passed in
      */
-    public static function urlsafeB64Encode($input)
+    public function urlsafeB64Encode($input)
     {
         return str_replace('=', '', strtr(base64_encode($input), '+/', '-_'));
     }
@@ -346,7 +346,7 @@ class JWT
      *
      * @return void
      */
-    private static function handleJsonError($errno)
+    private function handleJsonError($errno)
     {
         $messages = array(
             JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
@@ -369,7 +369,7 @@ class JWT
      *
      * @return int
      */
-    private static function safeStrlen($str)
+    private function safeStrlen($str)
     {
         if (function_exists('mb_strlen')) {
             return mb_strlen($str, '8bit');

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -10,35 +10,40 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testEncodeDecode()
     {
-        $msg = (new JWT())->encode('abc', 'my_key');
-        $this->assertEquals((new JWT())->decode($msg, 'my_key', array('HS256')), 'abc');
+        $jwt = new JWT();
+        $msg = $jwt->encode('abc', 'my_key');
+        $this->assertEquals($jwt->decode($msg, 'my_key', array('HS256')), 'abc');
     }
 
     public function testDecodeFromPython()
     {
         $msg = 'eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.Iio6aHR0cDovL2FwcGxpY2F0aW9uL2NsaWNreT9ibGFoPTEuMjMmZi5vbz00NTYgQUMwMDAgMTIzIg.E_U8X2YpMT5K1cEiT_3-IvBYfrdIFIeVYeOqre_Z5Cg';
+        $jwt = new JWT();
         $this->assertEquals(
-            (new JWT())->decode($msg, 'my_key', array('HS256')),
+            $jwt->decode($msg, 'my_key', array('HS256')),
             '*:http://application/clicky?blah=1.23&f.oo=456 AC000 123'
         );
     }
 
     public function testUrlSafeCharacters()
     {
-        $encoded = (new JWT())->encode('f?', 'a');
-        $this->assertEquals('f?', (new JWT())->decode($encoded, 'a', array('HS256')));
+        $jwt = new JWT();
+        $encoded = $jwt->encode('f?', 'a');
+        $this->assertEquals('f?', $jwt->decode($encoded, 'a', array('HS256')));
     }
 
     public function testMalformedUtf8StringsFail()
     {
         $this->setExpectedException('DomainException');
-        (new JWT())->encode(pack('c', 128), 'a');
+        $jwt = new JWT();
+        $jwt->encode(pack('c', 128), 'a');
     }
 
     public function testMalformedJsonThrowsException()
     {
         $this->setExpectedException('DomainException');
-        (new JWT())->jsonDecode('this is not valid JSON string');
+        $jwt = new JWT();
+        $jwt->jsonDecode('this is not valid JSON string');
     }
 
     public function testExpiredToken()
@@ -47,8 +52,9 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $payload = array(
             "message" => "abc",
             "exp" => time() - 20); // time in the past
-        $encoded = (new JWT())->encode($payload, 'my_key');
-        (new JWT())->decode($encoded, 'my_key', array('HS256'));
+        $jwt = new JWT();
+        $encoded = $jwt->encode($payload, 'my_key');
+        $jwt->decode($encoded, 'my_key', array('HS256'));
     }
 
     public function testBeforeValidTokenWithNbf()
@@ -57,8 +63,9 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $payload = array(
             "message" => "abc",
             "nbf" => time() + 20); // time in the future
-        $encoded = (new JWT())->encode($payload, 'my_key');
-        (new JWT())->decode($encoded, 'my_key', array('HS256'));
+        $jwt = new JWT();
+        $encoded = $jwt->encode($payload, 'my_key');
+        $jwt->decode($encoded, 'my_key', array('HS256'));
     }
 
     public function testBeforeValidTokenWithIat()
@@ -67,17 +74,19 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $payload = array(
             "message" => "abc",
             "iat" => time() + 20); // time in the future
-        $encoded = (new JWT())->encode($payload, 'my_key');
-        (new JWT())->decode($encoded, 'my_key', array('HS256'));
+        $jwt = new JWT();
+        $encoded = $jwt->encode($payload, 'my_key');
+        $jwt->decode($encoded, 'my_key', array('HS256'));
     }
 
     public function testValidToken()
     {
+        $jwt = new JWT();
         $payload = array(
             "message" => "abc",
-            "exp" => time() + (new JWT())->leeway + 20); // time in the future
-        $encoded = (new JWT())->encode($payload, 'my_key');
-        $decoded = (new JWT())->decode($encoded, 'my_key', array('HS256'));
+            "exp" => time() + $jwt->leeway + 20); // time in the future
+        $encoded = $jwt->encode($payload, 'my_key');
+        $decoded = $jwt->decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');
     }
 
@@ -108,23 +117,25 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testValidTokenWithList()
     {
+        $jwt = new JWT();
         $payload = array(
             "message" => "abc",
             "exp" => time() + 20); // time in the future
-        $encoded = (new JWT())->encode($payload, 'my_key');
-        $decoded = (new JWT())->decode($encoded, 'my_key', array('HS256', 'HS512'));
+        $encoded = $jwt->encode($payload, 'my_key');
+        $decoded = $jwt->decode($encoded, 'my_key', array('HS256', 'HS512'));
         $this->assertEquals($decoded->message, 'abc');
     }
 
     public function testValidTokenWithNbf()
     {
+        $jwt = new JWT();
         $payload = array(
             "message" => "abc",
             "iat" => time(),
             "exp" => time() + 20, // time in the future
             "nbf" => time() - 20);
-        $encoded = (new JWT())->encode($payload, 'my_key');
-        $decoded = (new JWT())->decode($encoded, 'my_key', array('HS256'));
+        $encoded = $jwt->encode($payload, 'my_key');
+        $decoded = $jwt->decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');
     }
 
@@ -180,109 +191,122 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testInvalidToken()
     {
+        $jwt = new JWT();
         $payload = array(
             "message" => "abc",
             "exp" => time() + 20); // time in the future
-        $encoded = (new JWT())->encode($payload, 'my_key');
+        $encoded = $jwt->encode($payload, 'my_key');
         $this->setExpectedException('Firebase\JWT\SignatureInvalidException');
-        $decoded = (new JWT())->decode($encoded, 'my_key2', array('HS256'));
+        $decoded = $jwt->decode($encoded, 'my_key2', array('HS256'));
     }
 
     public function testNullKeyFails()
     {
+        $jwt = new JWT();
         $payload = array(
             "message" => "abc",
-            "exp" => time() + (new JWT())->leeway + 20); // time in the future
-        $encoded = (new JWT())->encode($payload, 'my_key');
+            "exp" => time() + $jwt->leeway + 20); // time in the future
+        $encoded = $jwt->encode($payload, 'my_key');
         $this->setExpectedException('InvalidArgumentException');
-        $decoded = (new JWT())->decode($encoded, null, array('HS256'));
+        $decoded = $jwt->decode($encoded, null, array('HS256'));
     }
 
     public function testEmptyKeyFails()
     {
+        $jwt = new JWT();
         $payload = array(
             "message" => "abc",
-            "exp" => time() + (new JWT())->leeway + 20); // time in the future
-        $encoded = (new JWT())->encode($payload, 'my_key');
+            "exp" => time() + $jwt->leeway + 20); // time in the future
+        $encoded = $jwt->encode($payload, 'my_key');
         $this->setExpectedException('InvalidArgumentException');
-        $decoded = (new JWT())->decode($encoded, '', array('HS256'));
+        $decoded = $jwt->decode($encoded, '', array('HS256'));
     }
 
     public function testRSEncodeDecode()
     {
+        $jwt = new JWT();
         $privKey = openssl_pkey_new(array('digest_alg' => 'sha256',
             'private_key_bits' => 1024,
             'private_key_type' => OPENSSL_KEYTYPE_RSA));
-        $msg = (new JWT())->encode('abc', $privKey, 'RS256');
+        $msg = $jwt->encode('abc', $privKey, 'RS256');
         $pubKey = openssl_pkey_get_details($privKey);
         $pubKey = $pubKey['key'];
-        $decoded = (new JWT())->decode($msg, $pubKey, array('RS256'));
+        $decoded = $jwt->decode($msg, $pubKey, array('RS256'));
         $this->assertEquals($decoded, 'abc');
     }
 
     public function testKIDChooser()
     {
+        $jwt = new JWT();
         $keys = array('1' => 'my_key', '2' => 'my_key2');
-        $msg = (new JWT())->encode('abc', $keys['1'], 'HS256', '1');
-        $decoded = (new JWT())->decode($msg, $keys, array('HS256'));
+        $msg = $jwt->encode('abc', $keys['1'], 'HS256', '1');
+        $decoded = $jwt->decode($msg, $keys, array('HS256'));
         $this->assertEquals($decoded, 'abc');
     }
 
     public function testArrayAccessKIDChooser()
     {
+        $jwt = new JWT();
         $keys = new ArrayObject(array('1' => 'my_key', '2' => 'my_key2'));
-        $msg = (new JWT())->encode('abc', $keys['1'], 'HS256', '1');
-        $decoded = (new JWT())->decode($msg, $keys, array('HS256'));
+        $msg = $jwt->encode('abc', $keys['1'], 'HS256', '1');
+        $decoded = $jwt->decode($msg, $keys, array('HS256'));
         $this->assertEquals($decoded, 'abc');
     }
 
     public function testNoneAlgorithm()
     {
-        $msg = (new JWT())->encode('abc', 'my_key');
+        $jwt = new JWT();
+        $msg = $jwt->encode('abc', 'my_key');
         $this->setExpectedException('UnexpectedValueException');
-        (new JWT())->decode($msg, 'my_key', array('none'));
+        $jwt->decode($msg, 'my_key', array('none'));
     }
 
     public function testIncorrectAlgorithm()
     {
-        $msg = (new JWT())->encode('abc', 'my_key');
+        $jwt = new JWT();
+        $msg = $jwt->encode('abc', 'my_key');
         $this->setExpectedException('UnexpectedValueException');
-        (new JWT())->decode($msg, 'my_key', array('RS256'));
+        $jwt->decode($msg, 'my_key', array('RS256'));
     }
 
     public function testMissingAlgorithm()
     {
-        $msg = (new JWT())->encode('abc', 'my_key');
+        $jwt = new JWT();
+        $msg = $jwt->encode('abc', 'my_key');
         $this->setExpectedException('UnexpectedValueException');
-        (new JWT())->decode($msg, 'my_key');
+        $jwt->decode($msg, 'my_key');
     }
 
     public function testAdditionalHeaders()
     {
-        $msg = (new JWT())->encode('abc', 'my_key', 'HS256', null, array('cty' => 'test-eit;v=1'));
-        $this->assertEquals((new JWT())->decode($msg, 'my_key', array('HS256')), 'abc');
+        $jwt = new JWT();
+        $msg = $jwt->encode('abc', 'my_key', 'HS256', null, array('cty' => 'test-eit;v=1'));
+        $this->assertEquals($jwt->decode($msg, 'my_key', array('HS256')), 'abc');
     }
 
     public function testInvalidSegmentCount()
     {
+        $jwt = new JWT();
         $this->setExpectedException('UnexpectedValueException');
-        (new JWT())->decode('brokenheader.brokenbody', 'my_key', array('HS256'));
+        $jwt->decode('brokenheader.brokenbody', 'my_key', array('HS256'));
     }
 
     public function testInvalidSignatureEncoding()
     {
+        $jwt = new JWT();
         $msg = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwibmFtZSI6ImZvbyJ9.Q4Kee9E8o0Xfo4ADXvYA8t7dN_X_bU9K5w6tXuiSjlUxx";
         $this->setExpectedException('UnexpectedValueException');
-        (new JWT())->decode($msg, 'secret', array('HS256'));
+        $jwt->decode($msg, 'secret', array('HS256'));
     }
 
     public function testVerifyError()
     {
+        $jwt = new JWT();
         $this->setExpectedException('DomainException');
         $pkey = openssl_pkey_new();
-        $msg = (new JWT())->encode('abc', $pkey, 'RS256');
+        $msg = $jwt->encode('abc', $pkey, 'RS256');
         self::$opensslVerifyReturnValue = -1;
-        (new JWT())->decode($msg, $pkey, array('RS256'));
+        $jwt->decode($msg, $pkey, array('RS256'));
     }
 }
 

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -10,35 +10,35 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testEncodeDecode()
     {
-        $msg = JWT::encode('abc', 'my_key');
-        $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');
+        $msg = (new JWT())->encode('abc', 'my_key');
+        $this->assertEquals((new JWT())->decode($msg, 'my_key', array('HS256')), 'abc');
     }
 
     public function testDecodeFromPython()
     {
         $msg = 'eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.Iio6aHR0cDovL2FwcGxpY2F0aW9uL2NsaWNreT9ibGFoPTEuMjMmZi5vbz00NTYgQUMwMDAgMTIzIg.E_U8X2YpMT5K1cEiT_3-IvBYfrdIFIeVYeOqre_Z5Cg';
         $this->assertEquals(
-            JWT::decode($msg, 'my_key', array('HS256')),
+            (new JWT())->decode($msg, 'my_key', array('HS256')),
             '*:http://application/clicky?blah=1.23&f.oo=456 AC000 123'
         );
     }
 
     public function testUrlSafeCharacters()
     {
-        $encoded = JWT::encode('f?', 'a');
-        $this->assertEquals('f?', JWT::decode($encoded, 'a', array('HS256')));
+        $encoded = (new JWT())->encode('f?', 'a');
+        $this->assertEquals('f?', (new JWT())->decode($encoded, 'a', array('HS256')));
     }
 
     public function testMalformedUtf8StringsFail()
     {
         $this->setExpectedException('DomainException');
-        JWT::encode(pack('c', 128), 'a');
+        (new JWT())->encode(pack('c', 128), 'a');
     }
 
     public function testMalformedJsonThrowsException()
     {
         $this->setExpectedException('DomainException');
-        JWT::jsonDecode('this is not valid JSON string');
+        (new JWT())->jsonDecode('this is not valid JSON string');
     }
 
     public function testExpiredToken()
@@ -47,8 +47,8 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $payload = array(
             "message" => "abc",
             "exp" => time() - 20); // time in the past
-        $encoded = JWT::encode($payload, 'my_key');
-        JWT::decode($encoded, 'my_key', array('HS256'));
+        $encoded = (new JWT())->encode($payload, 'my_key');
+        (new JWT())->decode($encoded, 'my_key', array('HS256'));
     }
 
     public function testBeforeValidTokenWithNbf()
@@ -57,8 +57,8 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $payload = array(
             "message" => "abc",
             "nbf" => time() + 20); // time in the future
-        $encoded = JWT::encode($payload, 'my_key');
-        JWT::decode($encoded, 'my_key', array('HS256'));
+        $encoded = (new JWT())->encode($payload, 'my_key');
+        (new JWT())->decode($encoded, 'my_key', array('HS256'));
     }
 
     public function testBeforeValidTokenWithIat()
@@ -67,43 +67,43 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $payload = array(
             "message" => "abc",
             "iat" => time() + 20); // time in the future
-        $encoded = JWT::encode($payload, 'my_key');
-        JWT::decode($encoded, 'my_key', array('HS256'));
+        $encoded = (new JWT())->encode($payload, 'my_key');
+        (new JWT())->decode($encoded, 'my_key', array('HS256'));
     }
 
     public function testValidToken()
     {
         $payload = array(
             "message" => "abc",
-            "exp" => time() + JWT::$leeway + 20); // time in the future
-        $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+            "exp" => time() + (new JWT())->leeway + 20); // time in the future
+        $encoded = (new JWT())->encode($payload, 'my_key');
+        $decoded = (new JWT())->decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');
     }
 
     public function testValidTokenWithLeeway()
     {
-        JWT::$leeway = 60;
+        $jwt = new JWT();
+        $jwt->leeway = 60;
         $payload = array(
             "message" => "abc",
             "exp" => time() - 20); // time in the past
-        $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $encoded = $jwt->encode($payload, 'my_key');
+        $decoded = $jwt->decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');
-        JWT::$leeway = 0;
     }
 
     public function testExpiredTokenWithLeeway()
     {
-        JWT::$leeway = 60;
+        $jwt = new JWT();
+        $jwt->leeway = 60;
         $payload = array(
             "message" => "abc",
             "exp" => time() - 70); // time far in the past
         $this->setExpectedException('Firebase\JWT\ExpiredException');
-        $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $encoded = $jwt->encode($payload, 'my_key');
+        $decoded = $jwt->decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');
-        JWT::$leeway = 0;
     }
 
     public function testValidTokenWithList()
@@ -111,8 +111,8 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $payload = array(
             "message" => "abc",
             "exp" => time() + 20); // time in the future
-        $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256', 'HS512'));
+        $encoded = (new JWT())->encode($payload, 'my_key');
+        $decoded = (new JWT())->decode($encoded, 'my_key', array('HS256', 'HS512'));
         $this->assertEquals($decoded->message, 'abc');
     }
 
@@ -123,57 +123,59 @@ class JWTTest extends PHPUnit_Framework_TestCase
             "iat" => time(),
             "exp" => time() + 20, // time in the future
             "nbf" => time() - 20);
-        $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $encoded = (new JWT())->encode($payload, 'my_key');
+        $decoded = (new JWT())->decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');
     }
 
     public function testValidTokenWithNbfLeeway()
     {
-        JWT::$leeway = 60;
+        $jwt = new JWT();
+        $jwt->leeway = 60;
         $payload = array(
             "message" => "abc",
             "nbf"     => time() + 20); // not before in near (leeway) future
-        $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $encoded = $jwt->encode($payload, 'my_key');
+        $decoded = $jwt->decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');
-        JWT::$leeway = 0;
     }
 
     public function testInvalidTokenWithNbfLeeway()
     {
-        JWT::$leeway = 60;
+        $jwt = new JWT();
+        $jwt->leeway = 60;
         $payload = array(
             "message" => "abc",
             "nbf"     => time() + 65); // not before too far in future
-        $encoded = JWT::encode($payload, 'my_key');
+        $encoded = $jwt->encode($payload, 'my_key');
         $this->setExpectedException('Firebase\JWT\BeforeValidException');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
-        JWT::$leeway = 0;
+        $decoded = $jwt->decode($encoded, 'my_key', array('HS256'));
     }
 
     public function testValidTokenWithIatLeeway()
     {
-        JWT::$leeway = 60;
+        $jwt = new JWT();
+        $jwt->leeway = 60;
+
         $payload = array(
             "message" => "abc",
             "iat"     => time() + 20); // issued in near (leeway) future
-        $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $encoded = $jwt->encode($payload, 'my_key');
+        $decoded = $jwt->decode($encoded, 'my_key', array('HS256'));
         $this->assertEquals($decoded->message, 'abc');
-        JWT::$leeway = 0;
     }
 
     public function testInvalidTokenWithIatLeeway()
     {
-        JWT::$leeway = 60;
+        $jwt = new JWT();
+        $jwt->leeway = 60;
+
         $payload = array(
             "message" => "abc",
             "iat"     => time() + 65); // issued too far in future
-        $encoded = JWT::encode($payload, 'my_key');
+        $encoded = $jwt->encode($payload, 'my_key');
         $this->setExpectedException('Firebase\JWT\BeforeValidException');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
-        JWT::$leeway = 0;
+        $decoded = $jwt->decode($encoded, 'my_key', array('HS256'));
     }
 
     public function testInvalidToken()
@@ -181,29 +183,29 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $payload = array(
             "message" => "abc",
             "exp" => time() + 20); // time in the future
-        $encoded = JWT::encode($payload, 'my_key');
+        $encoded = (new JWT())->encode($payload, 'my_key');
         $this->setExpectedException('Firebase\JWT\SignatureInvalidException');
-        $decoded = JWT::decode($encoded, 'my_key2', array('HS256'));
+        $decoded = (new JWT())->decode($encoded, 'my_key2', array('HS256'));
     }
 
     public function testNullKeyFails()
     {
         $payload = array(
             "message" => "abc",
-            "exp" => time() + JWT::$leeway + 20); // time in the future
-        $encoded = JWT::encode($payload, 'my_key');
+            "exp" => time() + (new JWT())->leeway + 20); // time in the future
+        $encoded = (new JWT())->encode($payload, 'my_key');
         $this->setExpectedException('InvalidArgumentException');
-        $decoded = JWT::decode($encoded, null, array('HS256'));
+        $decoded = (new JWT())->decode($encoded, null, array('HS256'));
     }
 
     public function testEmptyKeyFails()
     {
         $payload = array(
             "message" => "abc",
-            "exp" => time() + JWT::$leeway + 20); // time in the future
-        $encoded = JWT::encode($payload, 'my_key');
+            "exp" => time() + (new JWT())->leeway + 20); // time in the future
+        $encoded = (new JWT())->encode($payload, 'my_key');
         $this->setExpectedException('InvalidArgumentException');
-        $decoded = JWT::decode($encoded, '', array('HS256'));
+        $decoded = (new JWT())->decode($encoded, '', array('HS256'));
     }
 
     public function testRSEncodeDecode()
@@ -211,76 +213,76 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $privKey = openssl_pkey_new(array('digest_alg' => 'sha256',
             'private_key_bits' => 1024,
             'private_key_type' => OPENSSL_KEYTYPE_RSA));
-        $msg = JWT::encode('abc', $privKey, 'RS256');
+        $msg = (new JWT())->encode('abc', $privKey, 'RS256');
         $pubKey = openssl_pkey_get_details($privKey);
         $pubKey = $pubKey['key'];
-        $decoded = JWT::decode($msg, $pubKey, array('RS256'));
+        $decoded = (new JWT())->decode($msg, $pubKey, array('RS256'));
         $this->assertEquals($decoded, 'abc');
     }
 
     public function testKIDChooser()
     {
         $keys = array('1' => 'my_key', '2' => 'my_key2');
-        $msg = JWT::encode('abc', $keys['1'], 'HS256', '1');
-        $decoded = JWT::decode($msg, $keys, array('HS256'));
+        $msg = (new JWT())->encode('abc', $keys['1'], 'HS256', '1');
+        $decoded = (new JWT())->decode($msg, $keys, array('HS256'));
         $this->assertEquals($decoded, 'abc');
     }
 
     public function testArrayAccessKIDChooser()
     {
         $keys = new ArrayObject(array('1' => 'my_key', '2' => 'my_key2'));
-        $msg = JWT::encode('abc', $keys['1'], 'HS256', '1');
-        $decoded = JWT::decode($msg, $keys, array('HS256'));
+        $msg = (new JWT())->encode('abc', $keys['1'], 'HS256', '1');
+        $decoded = (new JWT())->decode($msg, $keys, array('HS256'));
         $this->assertEquals($decoded, 'abc');
     }
 
     public function testNoneAlgorithm()
     {
-        $msg = JWT::encode('abc', 'my_key');
+        $msg = (new JWT())->encode('abc', 'my_key');
         $this->setExpectedException('UnexpectedValueException');
-        JWT::decode($msg, 'my_key', array('none'));
+        (new JWT())->decode($msg, 'my_key', array('none'));
     }
 
     public function testIncorrectAlgorithm()
     {
-        $msg = JWT::encode('abc', 'my_key');
+        $msg = (new JWT())->encode('abc', 'my_key');
         $this->setExpectedException('UnexpectedValueException');
-        JWT::decode($msg, 'my_key', array('RS256'));
+        (new JWT())->decode($msg, 'my_key', array('RS256'));
     }
 
     public function testMissingAlgorithm()
     {
-        $msg = JWT::encode('abc', 'my_key');
+        $msg = (new JWT())->encode('abc', 'my_key');
         $this->setExpectedException('UnexpectedValueException');
-        JWT::decode($msg, 'my_key');
+        (new JWT())->decode($msg, 'my_key');
     }
 
     public function testAdditionalHeaders()
     {
-        $msg = JWT::encode('abc', 'my_key', 'HS256', null, array('cty' => 'test-eit;v=1'));
-        $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');
+        $msg = (new JWT())->encode('abc', 'my_key', 'HS256', null, array('cty' => 'test-eit;v=1'));
+        $this->assertEquals((new JWT())->decode($msg, 'my_key', array('HS256')), 'abc');
     }
 
     public function testInvalidSegmentCount()
     {
         $this->setExpectedException('UnexpectedValueException');
-        JWT::decode('brokenheader.brokenbody', 'my_key', array('HS256'));
+        (new JWT())->decode('brokenheader.brokenbody', 'my_key', array('HS256'));
     }
 
     public function testInvalidSignatureEncoding()
     {
         $msg = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwibmFtZSI6ImZvbyJ9.Q4Kee9E8o0Xfo4ADXvYA8t7dN_X_bU9K5w6tXuiSjlUxx";
         $this->setExpectedException('UnexpectedValueException');
-        JWT::decode($msg, 'secret', array('HS256'));
+        (new JWT())->decode($msg, 'secret', array('HS256'));
     }
 
     public function testVerifyError()
     {
         $this->setExpectedException('DomainException');
         $pkey = openssl_pkey_new();
-        $msg = JWT::encode('abc', $pkey, 'RS256');
+        $msg = (new JWT())->encode('abc', $pkey, 'RS256');
         self::$opensslVerifyReturnValue = -1;
-        JWT::decode($msg, $pkey, array('RS256'));
+        (new JWT())->decode($msg, $pkey, array('RS256'));
     }
 }
 


### PR DESCRIPTION
To enable a well testing on class that use this code, we need to mock it.
To mock it, we can't use static calls. I remove all static code. 
I kept `$supported_algs` static because for me it's not considered as relative to the instance.