### PR TITLE
Update README to use SVG badge from Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/firebase/php-jwt.png?branch=master)](https://travis-ci.org/firebase/php-jwt)
+[![Build Status](https://travis-ci.org/firebase/php-jwt.svg?branch=master)](https://travis-ci.org/firebase/php-jwt)
 [![Latest Stable Version](https://poser.pugx.org/firebase/php-jwt/v/stable)](https://packagist.org/packages/firebase/php-jwt)
 [![Total Downloads](https://poser.pugx.org/firebase/php-jwt/downloads)](https://packagist.org/packages/firebase/php-jwt)
 [![License](https://poser.pugx.org/firebase/php-jwt/license)](https://packagist.org/packages/firebase/php-jwt)


### PR DESCRIPTION
The old PNG variant is rather pixelly on most modern screens.

The syntax used matches the current recommended Markdown
snippet as provided by Travis CI from the interface when viewing
https://travis-ci.org/firebase/php-jwt and clicking the badge.