### PR TITLE
Add resource type as 2nd param in decode method

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -51,9 +51,9 @@ class JWT
      *
      * @param string                    $jwt            The JWT
      * @param string|array|resource     $key            The key, or map of keys.
-     *                                      If the algorithm used is asymmetric, this is the public key
+     *                                                  If the algorithm used is asymmetric, this is the public key
      * @param array                     $allowed_algs   List of supported verification algorithms
-     *                                      Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'
+     *                                                  Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'
      *
      * @return object The JWT's payload as a PHP object
      *

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -49,10 +49,10 @@ class JWT
     /**
      * Decodes a JWT string into a PHP object.
      *
-     * @param string        $jwt            The JWT
-     * @param string|array  $key            The key, or map of keys.
+     * @param string                    $jwt            The JWT
+     * @param string|array|resource     $key            The key, or map of keys.
      *                                      If the algorithm used is asymmetric, this is the public key
-     * @param array         $allowed_algs   List of supported verification algorithms
+     * @param array                     $allowed_algs   List of supported verification algorithms
      *                                      Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'
      *
      * @return object The JWT's payload as a PHP object


### PR DESCRIPTION
It's a minor clarification of input parameters in `JWT::decode` method. 
Second parameter (key) accepts arrays, strings and resources, but in PHPDoc resource type is not listed.

Let's take a look at an example:
```php
<?php

$pubkey =<<<PUBKEY
-----BEGIN PUBLIC KEY-----
[...]
-----END PUBLIC KEY-----
PUBKEY;

$publicKey = openssl_pkey_get_public(pubkey); // $publicKey is a resource
$decodedToken = JWT::decode($token, $publicKey, ['RS256']);
```

If I run static analysis with PHPStan, I will get the following error:
```
Parameter #2 $key of static method Firebase\JWT\JWT::decode() expects array|string, resource given.
```