### PR TITLE
Changed $token to $payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Example
 use \Firebase\JWT\JWT;
 
 $key = "example_key";
-$token = array(
+$payload = array(
     "iss" => "http://example.org",
     "aud" => "http://example.com",
     "iat" => 1356999524,
@@ -36,7 +36,7 @@ $token = array(
  * https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40
  * for a list of spec-compliant algorithms.
  */
-$jwt = JWT::encode($token, $key);
+$jwt = JWT::encode($payload, $key);
 $decoded = JWT::decode($jwt, $key, array('HS256'));
 
 print_r($decoded);
@@ -93,14 +93,14 @@ ehde/zUxo6UvS7UrBQIDAQAB
 -----END PUBLIC KEY-----
 EOD;
 
-$token = array(
+$payload = array(
     "iss" => "example.org",
     "aud" => "example.com",
     "iat" => 1356999524,
     "nbf" => 1357000000
 );
 
-$jwt = JWT::encode($token, $privateKey, 'RS256');
+$jwt = JWT::encode($payload, $privateKey, 'RS256');
 echo "Encode:\n" . print_r($jwt, true) . "\n";
 
 $decoded = JWT::decode($jwt, $publicKey, array('RS256'));


### PR DESCRIPTION
Changed $token to $payload, at first sight it is not clearly why "$token" is names as $token since this "$token" represents the payload of the JWT.