### PR TITLE
Implement #183: Add ES256 support for Apple Push Notifications

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -38,9 +38,10 @@ class JWT
     public static $timestamp = null;
 
     public static $supported_algs = array(
+        'ES256' => array('openssl', 'SHA256'),
         'HS256' => array('hash_hmac', 'SHA256'),
-        'HS512' => array('hash_hmac', 'SHA512'),
         'HS384' => array('hash_hmac', 'SHA384'),
+        'HS512' => array('hash_hmac', 'SHA512'),
         'RS256' => array('openssl', 'SHA256'),
         'RS384' => array('openssl', 'SHA384'),
         'RS512' => array('openssl', 'SHA512'),
@@ -53,7 +54,7 @@ class JWT
      * @param string|array  $key            The key, or map of keys.
      *                                      If the algorithm used is asymmetric, this is the public key
      * @param array         $allowed_algs   List of supported verification algorithms
-     *                                      Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'
+     *                                      Supported algorithms are 'ES256', 'HS256', 'HS384', 'HS512', 'RS256', 'RS384', and 'RS512'
      *
      * @return object The JWT's payload as a PHP object
      *
@@ -144,7 +145,7 @@ class JWT
      * @param string        $key        The secret key.
      *                                  If the algorithm used is asymmetric, this is the private key
      * @param string        $alg        The signing algorithm.
-     *                                  Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'
+     *                                  Supported algorithms are 'ES256', 'HS256', 'HS384', 'HS512', 'RS256', 'RS384', and 'RS512'
      * @param mixed         $keyId
      * @param array         $head       An array with header elements to attach
      *
@@ -179,7 +180,7 @@ class JWT
      * @param string            $msg    The message to sign
      * @param string|resource   $key    The secret key
      * @param string            $alg    The signing algorithm.
-     *                                  Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'
+     *                                  Supported algorithms are 'ES256', 'HS256', 'HS384', 'HS512', 'RS256', 'RS384', and 'RS512'
      *
      * @return string An encrypted message
      *


### PR DESCRIPTION
Apple Push Notifications require the JWT algorithm be ES256. It still uses OpenSSL and SHA256 just like RS256, but the algorithm name in the headers must be "ES256" or else the token is rejected as invalid. This simple change adds support for ES256 and improves documentation regarding supported algorithms, which should close #183. I tested this locally, and this change alone allowed me to sent APNs, while I could not without this change.