### PR TITLE
allow alternate timestamp types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -12,6 +10,10 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
 
 sudo: false
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -70,6 +70,14 @@ class JWT
     {
         $timestamp = is_null(static::$timestamp) ? time() : static::$timestamp;
 
+        if ($timestamp instanceof DateTime) {
+            $timestamp = $timestamp->getTimeStamp();
+        } elseif (is_string($timestamp)) {
+            if (false !== ($time = strtotime($timestamp))) {
+                $timestamp = $time;
+            }
+        }
+
         if (empty($key)) {
             throw new InvalidArgumentException('Key may not be empty');
         }

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -5,6 +5,7 @@ use \DomainException;
 use \InvalidArgumentException;
 use \UnexpectedValueException;
 use \DateTime;
+use \DateTimeZone;
 
 /**
  * JSON Web Token implementation, based on this spec:
@@ -71,7 +72,7 @@ class JWT
         $timestamp = is_null(static::$timestamp) ? time() : static::$timestamp;
 
         if ($timestamp instanceof DateTime) {
-            $timestamp = $timestamp->getTimeStamp();
+            $timestamp = $timestamp->setTimeZone(new DateTimeZone("UTC"))->getTimeStamp();
         } elseif (is_string($timestamp)) {
             if (false !== ($time = strtotime($timestamp))) {
                 $timestamp = $time;

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -2,6 +2,7 @@
 namespace Firebase\JWT;
 
 use ArrayObject;
+use DateTime;
 use PHPUnit_Framework_TestCase;
 
 class JWTTest extends PHPUnit_Framework_TestCase
@@ -281,6 +282,45 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $msg = JWT::encode('abc', $pkey, 'RS256');
         self::$opensslVerifyReturnValue = -1;
         JWT::decode($msg, $pkey, array('RS256'));
+    }
+
+    public function testStringDatetimeTimestamp()
+    {
+        // reset the leeway to the default
+        JWT::$leeway = 0;
+        $payload = array(
+            "message" => "abc",
+            "iat" => 1502064545); // time way in the past
+        // a non-numeric timestamp
+        JWT::$timestamp = "2019-08-06T00:12:48.799";
+        $encoded = JWT::encode($payload, 'my_key');
+        JWT::decode($encoded, 'my_key', array('HS256'));
+    }
+
+    public function testNumericStringTimestamp()
+    {
+        // reset the leeway to the default
+        JWT::$leeway = 0;
+        $payload = array(
+            "message" => "abc",
+            "iat" => 1502064545); // time way in the past
+        // ensure compatibility with stringy numerics
+        JWT::$timestamp = "1502064545";
+        $encoded = JWT::encode($payload, 'my_key');
+        JWT::decode($encoded, 'my_key', array('HS256'));
+    }
+
+    public function testDatetimeTimestamp()
+    {
+        // reset the leeway to the default
+        JWT::$leeway = 0;
+        $payload = array(
+            "message" => "abc",
+            "iat" => 1502064545); // time way in the past
+        // a non-numeric timestamp
+        JWT::$timestamp = new DateTime('2019-08-06T15:03:01.012345Z');
+        $encoded = JWT::encode($payload, 'my_key');
+        JWT::decode($encoded, 'my_key', array('HS256'));
     }
 }
 


### PR DESCRIPTION
Setting `static::$timestamp` to other data types besides a numeric can sometimes produce false positives because of type casting while performing arithmetic operations.

In addition, it might be helpful to allow the `DateTime` object as a valid type as it might benefit developers including `nesbot/carbon` in respective projects.