### PR TITLE
Support ES256.

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -44,6 +44,7 @@ class JWT
         'RS256' => array('openssl', 'SHA256'),
         'RS384' => array('openssl', 'SHA384'),
         'RS512' => array('openssl', 'SHA512'),
+		'ES256' => array('openssl', 'SHA256'),
     );
 
     /**

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -44,7 +44,7 @@ class JWT
         'RS256' => array('openssl', 'SHA256'),
         'RS384' => array('openssl', 'SHA384'),
         'RS512' => array('openssl', 'SHA512'),
-		'ES256' => array('openssl', 'SHA256'),
+        'ES256' => array('openssl', 'SHA256'),
     );
 
     /**

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -206,17 +206,29 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $decoded = JWT::decode($encoded, '', array('HS256'));
     }
 
-    public function testRSEncodeDecode()
-    {
-        $privKey = openssl_pkey_new(array('digest_alg' => 'sha256',
-            'private_key_bits' => 1024,
-            'private_key_type' => OPENSSL_KEYTYPE_RSA));
-        $msg = JWT::encode('abc', $privKey, 'RS256');
-        $pubKey = openssl_pkey_get_details($privKey);
-        $pubKey = $pubKey['key'];
-        $decoded = JWT::decode($msg, $pubKey, array('RS256'));
-        $this->assertEquals($decoded, 'abc');
-    }
+	public function testRSEncodeDecode()
+	{
+		$privKey = openssl_pkey_new(array('digest_alg' => 'sha256',
+			'private_key_bits' => 1024,
+			'private_key_type' => OPENSSL_KEYTYPE_RSA));
+		$msg = JWT::encode('abc', $privKey, 'RS256');
+		$pubKey = openssl_pkey_get_details($privKey);
+		$pubKey = $pubKey['key'];
+		$decoded = JWT::decode($msg, $pubKey, array('RS256'));
+		$this->assertEquals($decoded, 'abc');
+	}
+
+	public function testESEncodeDecode()
+	{
+		$privKey = openssl_pkey_new(array('digest_alg' => 'sha256',
+			'private_key_bits' => 1024,
+			'private_key_type' => OPENSSL_KEYTYPE_RSA));
+		$msg = JWT::encode('abc', $privKey, 'ES256');
+		$pubKey = openssl_pkey_get_details($privKey);
+		$pubKey = $pubKey['key'];
+		$decoded = JWT::decode($msg, $pubKey, array('ES256'));
+		$this->assertEquals($decoded, 'abc');
+	}
 
     public function testKIDChooser()
     {


### PR DESCRIPTION
I'm personally not sure if this is actually the correct way but Apple Push Notification Service (APNS) supports RS256 keys if the `alg` header is set to ES256, so I'm guessing it's the same with a different name?

I would like to have someone with more knowledge look at this to verify.