### PR TITLE
Remove extra whitespace in if

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -159,7 +159,7 @@ class JWT
         if ($keyId !== null) {
             $header['kid'] = $keyId;
         }
-        if ( isset($head) && is_array($head) ) {
+        if (isset($head) && is_array($head)) {
             $header = array_merge($head, $header);
         }
         $segments = array();


### PR DESCRIPTION
None of the other if-statements have this extra whitespace. Is this used to signal something, or is this simply a style discrepancy?