### PR TITLE
[v6.0] Use array short syntax (introduced in php 5.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Example
 use \Firebase\JWT\JWT;
 
 $key = "example_key";
-$payload = array(
+$payload = [
     "iss" => "http://example.org",
     "aud" => "http://example.com",
     "iat" => 1356999524,
     "nbf" => 1357000000
-);
+];
 
 /**
  * IMPORTANT:
@@ -37,7 +37,7 @@ $payload = array(
  * for a list of spec-compliant algorithms.
  */
 $jwt = JWT::encode($payload, $key);
-$decoded = JWT::decode($jwt, $key, array('HS256'));
+$decoded = JWT::decode($jwt, $key, ['HS256']);
 
 print_r($decoded);
 
@@ -56,7 +56,7 @@ $decoded_array = (array) $decoded;
  * Source: http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#nbfDef
  */
 JWT::$leeway = 60; // $leeway in seconds
-$decoded = JWT::decode($jwt, $key, array('HS256'));
+$decoded = JWT::decode($jwt, $key, ['HS256']);
 
 ?>
 ```
@@ -103,7 +103,7 @@ $payload = array(
 $jwt = JWT::encode($payload, $privateKey, 'RS256');
 echo "Encode:\n" . print_r($jwt, true) . "\n";
 
-$decoded = JWT::decode($jwt, $publicKey, array('RS256'));
+$decoded = JWT::decode($jwt, $publicKey, ['RS256']);
 
 /*
  NOTE: This will now be an object instead of an associative array. To get

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Firebase\JWT;
+
 use \DomainException;
 use \InvalidArgumentException;
 use \UnexpectedValueException;
@@ -38,13 +39,13 @@ class JWT
     public static $timestamp = null;
 
     public static $supported_algs = array(
-        'ES256' => array('openssl', 'SHA256'),
-        'HS256' => array('hash_hmac', 'SHA256'),
-        'HS384' => array('hash_hmac', 'SHA384'),
-        'HS512' => array('hash_hmac', 'SHA512'),
-        'RS256' => array('openssl', 'SHA256'),
-        'RS384' => array('openssl', 'SHA384'),
-        'RS512' => array('openssl', 'SHA512'),
+        'ES256' => ['openssl', 'SHA256'],
+        'HS256' => ['hash_hmac', 'SHA256'],
+        'HS384' => ['hash_hmac', 'SHA384'],
+        'HS512' => ['hash_hmac', 'SHA512'],
+        'RS256' => ['openssl', 'SHA256'],
+        'RS384' => ['openssl', 'SHA384'],
+        'RS512' => ['openssl', 'SHA512'],
     );
 
     /**
@@ -67,7 +68,7 @@ class JWT
      * @uses jsonDecode
      * @uses urlsafeB64Decode
      */
-    public static function decode($jwt, $key, array $allowed_algs = array())
+    public static function decode($jwt, $key, array $allowed_algs = [])
     {
         $timestamp = is_null(static::$timestamp) ? time() : static::$timestamp;
 
@@ -156,14 +157,14 @@ class JWT
      */
     public static function encode($payload, $key, $alg = 'HS256', $keyId = null, $head = null)
     {
-        $header = array('typ' => 'JWT', 'alg' => $alg);
+        $header = ['typ' => 'JWT', 'alg' => $alg];
         if ($keyId !== null) {
             $header['kid'] = $keyId;
         }
         if (isset($head) && is_array($head)) {
             $header = array_merge($head, $header);
         }
-        $segments = array();
+        $segments = [];
         $segments[] = static::urlsafeB64Encode(static::jsonEncode($header));
         $segments[] = static::urlsafeB64Encode(static::jsonEncode($payload));
         $signing_input = implode('.', $segments);
@@ -192,7 +193,7 @@ class JWT
             throw new DomainException('Algorithm not supported');
         }
         list($function, $algorithm) = static::$supported_algs[$alg];
-        switch($function) {
+        switch ($function) {
             case 'hash_hmac':
                 return hash_hmac($algorithm, $msg, $key, true);
             case 'openssl':
@@ -226,7 +227,7 @@ class JWT
         }
 
         list($function, $algorithm) = static::$supported_algs[$alg];
-        switch($function) {
+        switch ($function) {
             case 'openssl':
                 $success = openssl_verify($msg, $signature, $key, $algorithm);
                 if ($success === 1) {
@@ -349,13 +350,13 @@ class JWT
      */
     private static function handleJsonError($errno)
     {
-        $messages = array(
+        $messages = [
             JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
             JSON_ERROR_STATE_MISMATCH => 'Invalid or malformed JSON',
             JSON_ERROR_CTRL_CHAR => 'Unexpected control character found',
             JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON',
-            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters' //PHP >= 5.3.3
-        );
+            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters'
+        ];
         throw new DomainException(
             isset($messages[$errno])
             ? $messages[$errno]

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -11,14 +11,14 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testEncodeDecode()
     {
         $msg = JWT::encode('abc', 'my_key');
-        $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');
+        $this->assertEquals(JWT::decode($msg, 'my_key', ['HS256']), 'abc');
     }
 
     public function testDecodeFromPython()
     {
         $msg = 'eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.Iio6aHR0cDovL2FwcGxpY2F0aW9uL2NsaWNreT9ibGFoPTEuMjMmZi5vbz00NTYgQUMwMDAgMTIzIg.E_U8X2YpMT5K1cEiT_3-IvBYfrdIFIeVYeOqre_Z5Cg';
         $this->assertEquals(
-            JWT::decode($msg, 'my_key', array('HS256')),
+            JWT::decode($msg, 'my_key', ['HS256']),
             '*:http://application/clicky?blah=1.23&f.oo=456 AC000 123'
         );
     }
@@ -26,7 +26,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testUrlSafeCharacters()
     {
         $encoded = JWT::encode('f?', 'a');
-        $this->assertEquals('f?', JWT::decode($encoded, 'a', array('HS256')));
+        $this->assertEquals('f?', JWT::decode($encoded, 'a', ['HS256']));
     }
 
     public function testMalformedUtf8StringsFail()
@@ -44,51 +44,56 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testExpiredToken()
     {
         $this->setExpectedException('Firebase\JWT\ExpiredException');
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "exp" => time() - 20); // time in the past
+            "exp" => time() - 20 // time in the past
+        ];
         $encoded = JWT::encode($payload, 'my_key');
-        JWT::decode($encoded, 'my_key', array('HS256'));
+        JWT::decode($encoded, 'my_key', ['HS256']);
     }
 
     public function testBeforeValidTokenWithNbf()
     {
         $this->setExpectedException('Firebase\JWT\BeforeValidException');
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "nbf" => time() + 20); // time in the future
+            "nbf" => time() + 20 // time in the future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
-        JWT::decode($encoded, 'my_key', array('HS256'));
+        JWT::decode($encoded, 'my_key', ['HS256']);
     }
 
     public function testBeforeValidTokenWithIat()
     {
         $this->setExpectedException('Firebase\JWT\BeforeValidException');
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "iat" => time() + 20); // time in the future
+            "iat" => time() + 20 // time in the future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
-        JWT::decode($encoded, 'my_key', array('HS256'));
+        JWT::decode($encoded, 'my_key', ['HS256']);
     }
 
     public function testValidToken()
     {
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "exp" => time() + JWT::$leeway + 20); // time in the future
+            "exp" => time() + JWT::$leeway + 20 // time in the future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $decoded = JWT::decode($encoded, 'my_key', ['HS256']);
         $this->assertEquals($decoded->message, 'abc');
     }
 
     public function testValidTokenWithLeeway()
     {
         JWT::$leeway = 60;
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "exp" => time() - 20); // time in the past
+            "exp" => time() - 20 // time in the past
+        ];
         $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $decoded = JWT::decode($encoded, 'my_key', ['HS256']);
         $this->assertEquals($decoded->message, 'abc');
         JWT::$leeway = 0;
     }
@@ -96,46 +101,50 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testExpiredTokenWithLeeway()
     {
         JWT::$leeway = 60;
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "exp" => time() - 70); // time far in the past
+            "exp" => time() - 70 // time far in the past
+        ];
         $this->setExpectedException('Firebase\JWT\ExpiredException');
         $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $decoded = JWT::decode($encoded, 'my_key', ['HS256']);
         $this->assertEquals($decoded->message, 'abc');
         JWT::$leeway = 0;
     }
 
     public function testValidTokenWithList()
     {
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "exp" => time() + 20); // time in the future
+            "exp" => time() + 20 // time in the future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256', 'HS512'));
+        $decoded = JWT::decode($encoded, 'my_key', ['HS256', 'HS512']);
         $this->assertEquals($decoded->message, 'abc');
     }
 
     public function testValidTokenWithNbf()
     {
-        $payload = array(
+        $payload = [
             "message" => "abc",
             "iat" => time(),
             "exp" => time() + 20, // time in the future
-            "nbf" => time() - 20);
+            "nbf" => time() - 20
+        ];
         $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $decoded = JWT::decode($encoded, 'my_key', ['HS256']);
         $this->assertEquals($decoded->message, 'abc');
     }
 
     public function testValidTokenWithNbfLeeway()
     {
         JWT::$leeway = 60;
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "nbf"     => time() + 20); // not before in near (leeway) future
+            "nbf"     => time() + 20 // not before in near (leeway) future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $decoded = JWT::decode($encoded, 'my_key', ['HS256']);
         $this->assertEquals($decoded->message, 'abc');
         JWT::$leeway = 0;
     }
@@ -143,23 +152,25 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testInvalidTokenWithNbfLeeway()
     {
         JWT::$leeway = 60;
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "nbf"     => time() + 65); // not before too far in future
+            "nbf"     => time() + 65 // not before too far in future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
         $this->setExpectedException('Firebase\JWT\BeforeValidException');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $decoded = JWT::decode($encoded, 'my_key', ['HS256']);
         JWT::$leeway = 0;
     }
 
     public function testValidTokenWithIatLeeway()
     {
         JWT::$leeway = 60;
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "iat"     => time() + 20); // issued in near (leeway) future
+            "iat"     => time() + 20 // issued in near (leeway) future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $decoded = JWT::decode($encoded, 'my_key', ['HS256']);
         $this->assertEquals($decoded->message, 'abc');
         JWT::$leeway = 0;
     }
@@ -167,70 +178,76 @@ class JWTTest extends PHPUnit_Framework_TestCase
     public function testInvalidTokenWithIatLeeway()
     {
         JWT::$leeway = 60;
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "iat"     => time() + 65); // issued too far in future
+            "iat"     => time() + 65 // issued too far in future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
         $this->setExpectedException('Firebase\JWT\BeforeValidException');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        $decoded = JWT::decode($encoded, 'my_key', ['HS256']);
         JWT::$leeway = 0;
     }
 
     public function testInvalidToken()
     {
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "exp" => time() + 20); // time in the future
+            "exp" => time() + 20 // time in the future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
         $this->setExpectedException('Firebase\JWT\SignatureInvalidException');
-        $decoded = JWT::decode($encoded, 'my_key2', array('HS256'));
+        $decoded = JWT::decode($encoded, 'my_key2', ['HS256']);
     }
 
     public function testNullKeyFails()
     {
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "exp" => time() + JWT::$leeway + 20); // time in the future
+            "exp" => time() + JWT::$leeway + 20 // time in the future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
         $this->setExpectedException('InvalidArgumentException');
-        $decoded = JWT::decode($encoded, null, array('HS256'));
+        $decoded = JWT::decode($encoded, null, ['HS256']);
     }
 
     public function testEmptyKeyFails()
     {
-        $payload = array(
+        $payload = [
             "message" => "abc",
-            "exp" => time() + JWT::$leeway + 20); // time in the future
+            "exp" => time() + JWT::$leeway + 20 // time in the future
+        ];
         $encoded = JWT::encode($payload, 'my_key');
         $this->setExpectedException('InvalidArgumentException');
-        $decoded = JWT::decode($encoded, '', array('HS256'));
+        $decoded = JWT::decode($encoded, '', ['HS256']);
     }
 
     public function testRSEncodeDecode()
     {
-        $privKey = openssl_pkey_new(array('digest_alg' => 'sha256',
+        $privKey = openssl_pkey_new([
+            'digest_alg' => 'sha256',
             'private_key_bits' => 1024,
-            'private_key_type' => OPENSSL_KEYTYPE_RSA));
+            'private_key_type' => OPENSSL_KEYTYPE_RSA
+        ]);
         $msg = JWT::encode('abc', $privKey, 'RS256');
         $pubKey = openssl_pkey_get_details($privKey);
         $pubKey = $pubKey['key'];
-        $decoded = JWT::decode($msg, $pubKey, array('RS256'));
+        $decoded = JWT::decode($msg, $pubKey, ['RS256']);
         $this->assertEquals($decoded, 'abc');
     }
 
     public function testKIDChooser()
     {
-        $keys = array('1' => 'my_key', '2' => 'my_key2');
+        $keys = ['1' => 'my_key', '2' => 'my_key2'];
         $msg = JWT::encode('abc', $keys['1'], 'HS256', '1');
-        $decoded = JWT::decode($msg, $keys, array('HS256'));
+        $decoded = JWT::decode($msg, $keys, ['HS256']);
         $this->assertEquals($decoded, 'abc');
     }
 
     public function testArrayAccessKIDChooser()
     {
-        $keys = new ArrayObject(array('1' => 'my_key', '2' => 'my_key2'));
+        $keys = new ArrayObject(['1' => 'my_key', '2' => 'my_key2']);
         $msg = JWT::encode('abc', $keys['1'], 'HS256', '1');
-        $decoded = JWT::decode($msg, $keys, array('HS256'));
+        $decoded = JWT::decode($msg, $keys, ['HS256']);
         $this->assertEquals($decoded, 'abc');
     }
 
@@ -238,14 +255,14 @@ class JWTTest extends PHPUnit_Framework_TestCase
     {
         $msg = JWT::encode('abc', 'my_key');
         $this->setExpectedException('UnexpectedValueException');
-        JWT::decode($msg, 'my_key', array('none'));
+        JWT::decode($msg, 'my_key', ['none']);
     }
 
     public function testIncorrectAlgorithm()
     {
         $msg = JWT::encode('abc', 'my_key');
         $this->setExpectedException('UnexpectedValueException');
-        JWT::decode($msg, 'my_key', array('RS256'));
+        JWT::decode($msg, 'my_key', ['RS256']);
     }
 
     public function testMissingAlgorithm()
@@ -257,21 +274,21 @@ class JWTTest extends PHPUnit_Framework_TestCase
 
     public function testAdditionalHeaders()
     {
-        $msg = JWT::encode('abc', 'my_key', 'HS256', null, array('cty' => 'test-eit;v=1'));
-        $this->assertEquals(JWT::decode($msg, 'my_key', array('HS256')), 'abc');
+        $msg = JWT::encode('abc', 'my_key', 'HS256', null, ['cty' => 'test-eit;v=1']);
+        $this->assertEquals(JWT::decode($msg, 'my_key', ['HS256']), 'abc');
     }
 
     public function testInvalidSegmentCount()
     {
         $this->setExpectedException('UnexpectedValueException');
-        JWT::decode('brokenheader.brokenbody', 'my_key', array('HS256'));
+        JWT::decode('brokenheader.brokenbody', 'my_key', ['HS256']);
     }
 
     public function testInvalidSignatureEncoding()
     {
         $msg = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwibmFtZSI6ImZvbyJ9.Q4Kee9E8o0Xfo4ADXvYA8t7dN_X_bU9K5w6tXuiSjlUxx";
         $this->setExpectedException('UnexpectedValueException');
-        JWT::decode($msg, 'secret', array('HS256'));
+        JWT::decode($msg, 'secret', ['HS256']);
     }
 
     public function testVerifyError()
@@ -280,7 +297,7 @@ class JWTTest extends PHPUnit_Framework_TestCase
         $pkey = openssl_pkey_new();
         $msg = JWT::encode('abc', $pkey, 'RS256');
         self::$opensslVerifyReturnValue = -1;
-        JWT::decode($msg, $pkey, array('RS256'));
+        JWT::decode($msg, $pkey, ['RS256']);
     }
 }
 


### PR DESCRIPTION
I updated the code to use the short array syntax which is much more common today and more familiar to developers new to the language. This requires php 5.4 which is why I tagged this for v6.0.