### PR TITLE
Use mb_strlen without unnecessary existence check

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -372,9 +372,6 @@ class JWT
      */
     private static function safeStrlen($str)
     {
-        if (function_exists('mb_strlen')) {
-            return mb_strlen($str, '8bit');
-        }
-        return strlen($str);
+        return mb_strlen($str, '8bit');
     }
 }


### PR DESCRIPTION
mb_strlen exists in all version of PHP 5 and this package requires at least php 5.3.0, so the existence check is unnecessary.