### PR TITLE
Allow composer to choose the latest phpunit major version matching each PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5"
+        "phpunit/phpunit": ">=4.8 <=9"
     }
 }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -8,6 +8,17 @@ class JWTTest extends TestCase
 {
     public static $opensslVerifyReturnValue;
 
+    /*
+     * For compatibility with PHPUnit 4.8 and PHP < 5.6
+     */
+    public function setExpectedException($exceptionName, $message = '', $code = NULL) {
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($exceptionName);
+        } else {
+            parent::setExpectedException($exceptionName, $message, $code);
+        }
+    }
+
     public function testEncodeDecode()
     {
         $msg = JWT::encode('abc', 'my_key');


### PR DESCRIPTION
It is possible to run with the latest `phpunit` that goes with each version of PHP.
To keep supporting the very old versions of PHP and `phpunit` I  had to add some version checks in the unit tests to choose whether to use `setExpectedException` or `expectException`. That could also probably be done with `method_exists`

What do you think about this approach, using modern versions of `phpunit` where we can?