### PR TITLE
Cleanup code

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -448,7 +448,7 @@ class JWT
      * Encodes signature from a DER object.
      *
      * @param   string  $der binary signature in DER format
-     * @param   int     $keySize the nubmer of bits in the key
+     * @param   int     $keySize the number of bits in the key
      * @return  string  the signature
      */
     private static function signatureFromDER($der, $keySize)

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -148,7 +148,7 @@ class JWTTest extends TestCase
             "nbf"     => time() + 65); // not before too far in future
         $encoded = JWT::encode($payload, 'my_key');
         $this->setExpectedException('Firebase\JWT\BeforeValidException');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        JWT::decode($encoded, 'my_key', array('HS256'));
         JWT::$leeway = 0;
     }
 
@@ -172,7 +172,7 @@ class JWTTest extends TestCase
             "iat"     => time() + 65); // issued too far in future
         $encoded = JWT::encode($payload, 'my_key');
         $this->setExpectedException('Firebase\JWT\BeforeValidException');
-        $decoded = JWT::decode($encoded, 'my_key', array('HS256'));
+        JWT::decode($encoded, 'my_key', array('HS256'));
         JWT::$leeway = 0;
     }
 
@@ -183,7 +183,7 @@ class JWTTest extends TestCase
             "exp" => time() + 20); // time in the future
         $encoded = JWT::encode($payload, 'my_key');
         $this->setExpectedException('Firebase\JWT\SignatureInvalidException');
-        $decoded = JWT::decode($encoded, 'my_key2', array('HS256'));
+        JWT::decode($encoded, 'my_key2', array('HS256'));
     }
 
     public function testNullKeyFails()
@@ -193,7 +193,7 @@ class JWTTest extends TestCase
             "exp" => time() + JWT::$leeway + 20); // time in the future
         $encoded = JWT::encode($payload, 'my_key');
         $this->setExpectedException('InvalidArgumentException');
-        $decoded = JWT::decode($encoded, null, array('HS256'));
+        JWT::decode($encoded, null, array('HS256'));
     }
 
     public function testEmptyKeyFails()
@@ -203,7 +203,7 @@ class JWTTest extends TestCase
             "exp" => time() + JWT::$leeway + 20); // time in the future
         $encoded = JWT::encode($payload, 'my_key');
         $this->setExpectedException('InvalidArgumentException');
-        $decoded = JWT::decode($encoded, '', array('HS256'));
+        JWT::decode($encoded, '', array('HS256'));
     }
 
     public function testRSEncodeDecode()


### PR DESCRIPTION
1) remove unused variables from unit test code (those tests expect an exception, there is no need to assign the result to a variable)
2) fix a typo in PHP doc