### PR TITLE
Validation of iat and nbf should be greater than or equal to.

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -124,7 +124,7 @@ class JWT
 
         // Check the nbf if it is defined. This is the time that the
         // token can actually be used. If it's not yet that time, abort.
-        if (isset($payload->nbf) && $payload->nbf > ($timestamp + static::$leeway)) {
+        if (isset($payload->nbf) && $payload->nbf >= ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
                 'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->nbf)
             );
@@ -133,7 +133,7 @@ class JWT
         // Check that this token has been created before 'now'. This prevents
         // using tokens that have been created for later use (and haven't
         // correctly used the nbf claim).
-        if (isset($payload->iat) && $payload->iat > ($timestamp + static::$leeway)) {
+        if (isset($payload->iat) && $payload->iat >= ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
                 'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->iat)
             );


### PR DESCRIPTION
This issue bit us a bit today as we upgraded to PHP 7.4 and had a marked improvement on performance. Upon setting the JWT token with an `iat` set to `time()`, the token was not immediately usable by the frontend client.

I believe both the calculations for `iat` and `nbf` should include the current time.

In the meantime, We've added a `leeway` to work around this.