### PR TITLE
$payload->exp doesn't exists because the returned object has two prop…

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -124,7 +124,7 @@ class JWT
 
         // Check the nbf if it is defined. This is the time that the
         // token can actually be used. If it's not yet that time, abort.
-        if (isset($payload->nbf) && $payload->nbf > ($timestamp + static::$leeway)) {
+        if (isset($payload->payload->nbf) && $payload->payload->nbf > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
                 'Cannot handle token prior to ' . \date(DateTime::ISO8601, $payload->nbf)
             );
@@ -133,14 +133,14 @@ class JWT
         // Check that this token has been created before 'now'. This prevents
         // using tokens that have been created for later use (and haven't
         // correctly used the nbf claim).
-        if (isset($payload->iat) && $payload->iat > ($timestamp + static::$leeway)) {
+        if (isset($payload->payload->iat) && $payload->payload->iat > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
                 'Cannot handle token prior to ' . \date(DateTime::ISO8601, $payload->iat)
             );
         }
 
         // Check if this token has expired.
-        if (isset($payload->exp) && ($timestamp - static::$leeway) >= $payload->exp) {
+        if (isset($payload->payload->exp) && ($timestamp - static::$leeway) >= $payload->payload->exp) {
             throw new ExpiredException('Expired token');
         }
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -126,7 +126,7 @@ class JWT
         // token can actually be used. If it's not yet that time, abort.
         if (isset($payload->payload->nbf) && $payload->payload->nbf > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
-                'Cannot handle token prior to ' . \date(DateTime::ISO8601, $payload->nbf)
+                'Cannot handle token prior to ' . \date(DateTime::ISO8601, $payload->payload->nbf)
             );
         }
 
@@ -135,7 +135,7 @@ class JWT
         // correctly used the nbf claim).
         if (isset($payload->payload->iat) && $payload->payload->iat > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
-                'Cannot handle token prior to ' . \date(DateTime::ISO8601, $payload->iat)
+                'Cannot handle token prior to ' . \date(DateTime::ISO8601, $payload->payload->iat)
             );
         }
 


### PR DESCRIPTION
…erties header and payload

I am doing a little bit of testing and i think that the latest three ifs in this function never return true because the variable $payload->exp or $payload->iat or $payload->nbf doesn't exists i think that it has to be replaced by $payload->payload->exp, $payload->payload->iat and $payload->payload->nbf