### PR TITLE
PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - nightly #php 8
 
 matrix:
   include:

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.8 <=9"
+        "phpunit/phpunit": ">=4.8 <=10"
     }
 }


### PR DESCRIPTION
Hi,

to prepare for PHP 8, I added it to the travis config and adjusted the phpunit composer dependency to allow picking up phpunit 9.4.
Please let me know if you'd prefer this to be solved differently.