### PR TITLE
Add support for determining key based on entire JOSE header

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -116,6 +116,8 @@ class JWT
             } else {
                 throw new UnexpectedValueException('"kid" empty, unable to lookup correct key');
             }
+        } elseif ($key instanceof VerificationKeyInterface) {
+            $key = $key->verificationKey($header);
         }
 
         // Check the signature

--- a/src/VerificationKeyInterface.php
+++ b/src/VerificationKeyInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Firebase\JWT;
+
+use stdClass;
+
+/**
+ * Provide a specific key for signature verification based on token header.
+ */
+interface VerificationKeyInterface
+{
+    /**
+     * Make an informed decision of which key to use, based on the JOSE header
+     * in its entirety.
+     *
+     * @param stdClass $header JOSE header containing alg and optional values
+     *                         (kid, jku, jwk, etc.)
+     *
+     * @throws UnexpectedValueException
+     * @return string
+     */
+    public function verificationKey(stdClass $header);
+}

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -299,4 +299,21 @@ class JWTTest extends TestCase
 
         $this->assertEquals('bar', $decoded->foo);
     }
+
+    public function testKeyVerification()
+    {
+        $keys = array('HS256' => array('1' => 'my_key', '2' => 'my_key2'));
+        $keyProvider = $this->getMockBuilder(VerificationKeyInterface::class)->getMock();
+        $keyProvider->method('verificationKey')->willReturnCallback(function ($header) use ($keys) {
+            return $keys[$header->alg][$header->kid];
+        });
+
+        $msg = JWT::encode('abc', $keys['HS256']['1'], 'HS256', '1');
+        $decoded = JWT::decode($msg, $keyProvider, array('HS256'));
+        $this->assertEquals($decoded, 'abc');
+
+        $msg = JWT::encode('abc', $keys['HS256']['2'], 'HS256', '2');
+        $decoded = JWT::decode($msg, $keyProvider, array('HS256'));
+        $this->assertEquals($decoded, 'abc');
+    }
 }


### PR DESCRIPTION
The specs allow for header paramters such as alg, jwk, jku, x5c, etc., which could have a determining factor in how the key is chosen.

This PR provides an interface for implementing such logic.
