### PR TITLE
Add `/.github export-ignore` to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpunit.xml.dist export-ignore
+/.github export-ignore


### PR DESCRIPTION
Currently `firebase/php-jwt/.github/actions/entrypoint.sh` is also loaded via composer install.
This change removes it again.