### PR TITLE
Gracefully Prevent Keys from Ever Being Used for the Wrong Header-Specified Algorithm

### DIFF
--- a/src/Keys/JWTKey.php
+++ b/src/Keys/JWTKey.php
@@ -1,0 +1,113 @@
+<?php
+namespace Firebase\JWT\Keys;
+
+use Firebase\JWT\JWT;
+
+class JWTKey
+{
+    /** @var string $alg */
+    private $alg;
+
+    /** @var string $keyMaterial */
+    private $keyMaterial;
+
+    /**
+     * @param string $keyMaterial
+     * @param string|array|null $alg
+     */
+    public function __construct($keyMaterial, $alg = null)
+    {
+        if (is_array($alg)) {
+            $alg = self::guessAlgFromKeyMaterial($keyMaterial, $alg);
+        } elseif (is_null($alg)) {
+            $alg = self::guessAlgFromKeyMaterial($keyMaterial);
+        }
+        $this->keyMaterial = $keyMaterial;
+        $this->alg = $alg;
+    }
+
+    /**
+     * Is the header algorithm valid for this key?
+     *
+     * @param string $headerAlg
+     * @return bool
+     */
+    public function isValidForAlg($headerAlg)
+    {
+        return JWT::constantTimeEquals($this->alg, $headerAlg);
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeyMaterial()
+    {
+        return $this->keyMaterial;
+    }
+
+    /**
+     * This is a best-effort attempt to guess the algorithm for a given key
+     * based on its contents.
+     *
+     * It will probably be wrong in a lot of corner cases.
+     *
+     * If it is, construct a JWTKey object and/or Keyring of JWTKey objects
+     * with the correct algorithms.
+     *
+     * @param string $keyMaterial
+     * @param array $candidates
+     * @return string
+     */
+    public static function guessAlgFromKeyMaterial($keyMaterial, array $candidates = array())
+    {
+        $length = JWT::safeStrlen($keyMaterial);
+        if ($length >= 720) {
+            // RSA keys
+            if (preg_match('#^-+BEGIN.+(PRIVATE|PUBLIC) KEY-+#', $keyMaterial)) {
+                if (in_array('RS512', $candidates)) {
+                    return 'RS512';
+                }
+                if (in_array('RS384', $candidates)) {
+                    return 'RS384';
+                }
+                return 'RS256';
+            }
+        } elseif ($length >= 220) {
+            // ECDSA private keys
+            if (preg_match('#^-+BEGIN EC PRIVATE KEY-+#', $keyMaterial)) {
+                if (in_array('ES512', $candidates)) {
+                    return 'ES512';
+                }
+                if (in_array('ES384', $candidates)) {
+                    return 'ES384';
+                }
+                return 'ES256';
+            }
+        } elseif ($length >= 170) {
+            // ECDSA public keys
+            if (preg_match('#^-+BEGIN EC PUBLICY-+#', $keyMaterial)) {
+                if (in_array('ES512', $candidates)) {
+                    return 'ES512';
+                }
+                if (in_array('ES384', $candidates)) {
+                    return 'ES384';
+                }
+                return 'ES256';
+            }
+        } elseif ($length >= 40 && $length <= 88) {
+            // Likely base64-encoded EdDSA key
+            if (in_array('EdDSA', $candidates)) {
+                return 'EdDSA';
+            }
+        }
+
+        // Last resort: HMAC
+        if (in_array('HS512', $candidates)) {
+            return 'HS512';
+        }
+        if (in_array('HS384', $candidates)) {
+            return 'HS384';
+        }
+        return 'HS256';
+    }
+}

--- a/src/Keys/Keyring.php
+++ b/src/Keys/Keyring.php
@@ -1,0 +1,81 @@
+<?php
+namespace Firebase\JWT\Keys;
+
+use ArrayAccess;
+use RuntimeException;
+
+final class Keyring implements ArrayAccess
+{
+    /** @var array<string, JWTKey> $mapping */
+    private $mapping;
+
+    /**
+     * @param array<string, JWTKey> $mapping
+     */
+    public function __construct(array $mapping = array())
+    {
+        $this->mapping = $mapping;
+    }
+
+    /**
+     * @param string $keyId
+     * @param JWTKey $key
+     * @return $this
+     */
+    public function mapKeyId($keyId, JWTKey $key)
+    {
+        $this->mapping[$keyId] = $key;
+        return $this;
+    }
+
+    /**
+     * @param mixed $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        if (!is_string($offset)) {
+            throw new RuntimeException('Type error: argument 1 must be a string');
+        }
+        return array_key_exists($offset, $this->mapping);
+    }
+
+    /**
+     * @param mixed $offset
+     * @return JWTKey
+     */
+    public function offsetGet($offset)
+    {
+        $value = $this->mapping[$offset];
+        if (!($value instanceof JWTKey)) {
+            throw new RuntimeException('Type error: return value not an instance of JWTKey');
+        }
+        return $value;
+    }
+
+    /**
+     * @param string $offset
+     * @param JWTKey $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (!is_string($offset)) {
+            throw new RuntimeException('Type error: argument 1 must be a string');
+        }
+        if (!($value instanceof JWTKey)) {
+            throw new RuntimeException('Type error: argument 2 must be an instance of JWT');
+        }
+        $this->mapKeyId($offset, $value);
+    }
+
+    /**
+     * @param string $offset
+     */
+    public function offsetUnset($offset)
+    {
+        if (!is_string($offset)) {
+            throw new RuntimeException('Type error: argument 1 must be a string');
+        }
+        unset($this->mapping[$offset]);
+    }
+}

--- a/tests/Keys/JWTKeyTest.php
+++ b/tests/Keys/JWTKeyTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace Firebase\JWT\Keys;
+
+use PHPUnit\Framework\TestCase;
+
+class JWTKeyTest extends TestCase
+{
+    public function testExpectedAlgGuess()
+    {
+        $eddsa = 'MpwwPe63YoDwAoO7EDBUOUb7J9lpdjt8vT+hfnLL39k=';
+        $ecc384 = $this->getEcdsaPublicKey();
+        $rsa = $this->getRsaPublicKey();
+        $misc = 'maybe_use_paseto_instead';
+
+        $this->assertSame(
+            'RS512',
+            JWTKey::guessAlgFromKeyMaterial($rsa, array('RS512'))
+        );
+        $this->assertSame(
+            'RS384',
+            JWTKey::guessAlgFromKeyMaterial($rsa, array('RS384'))
+        );
+        $this->assertSame(
+            'RS256',
+            JWTKey::guessAlgFromKeyMaterial($rsa, array('RS256'))
+        );
+        $this->assertSame(
+            'RS256',
+            JWTKey::guessAlgFromKeyMaterial($rsa)
+        );
+        $this->assertSame(
+            'ES384',
+            JWTKey::guessAlgFromKeyMaterial($ecc384, array('ES384'))
+        );
+        $this->assertSame(
+            'ES256',
+            JWTKey::guessAlgFromKeyMaterial($ecc384)
+        );
+        $this->assertSame(
+            'EdDSA',
+            JWTKey::guessAlgFromKeyMaterial($eddsa, array('EdDSA'))
+        );
+        $this->assertSame(
+            'HS256',
+            JWTKey::guessAlgFromKeyMaterial($eddsa)
+        );
+        $this->assertSame(
+            'HS384',
+            JWTKey::guessAlgFromKeyMaterial($misc, array('HS512'))
+        );
+        $this->assertSame(
+            'HS384',
+            JWTKey::guessAlgFromKeyMaterial($misc, array('HS384'))
+        );
+        $this->assertSame(
+            'HS256',
+            JWTKey::guessAlgFromKeyMaterial($misc, array('HS256'))
+        );
+        $this->assertSame(
+            'HS256',
+            JWTKey::guessAlgFromKeyMaterial($misc)
+        );
+    }
+
+    public function getRsaPublicKey()
+    {
+        $privKey = openssl_pkey_new(array('digest_alg' => 'sha256',
+            'private_key_bits' => 1024,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA));
+        $pubKey = openssl_pkey_get_details($privKey);
+        return $pubKey['key'];
+    }
+
+    public function getEcdsaPublicKey()
+    {
+        $privKey = openssl_pkey_new(
+            array(
+                'curve_name' => 'secp384r1',
+                'digest_alg' => 'sha384',
+                'private_key_bits' => 384,
+                'private_key_type' => OPENSSL_KEYTYPE_EC
+            )
+        );
+        $pubKey = openssl_pkey_get_details($privKey);
+        return $pubKey['key'];
+    }
+}


### PR DESCRIPTION
Proposed Fix for #351

This aims to provide backwards compatibility by guessing the algorithm for a key based on the key's contents, but it will likely fail in corner cases.

If this is merged, users **SHOULD** be explicit about the algorithms they're using.

i.e. Instead of $keyAsString, pass in (new JWTKey($keyAsString, 'ES384'))