### PR TITLE
Clarify JWT::encode() function call in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $payload = array(
  * https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40
  * for a list of spec-compliant algorithms.
  */
-$jwt = JWT::encode($payload, $key);
+$jwt = JWT::encode($payload, $key); // Optional third string argument for signing algorithm, 'HS256' is used by default.
 $decoded = JWT::decode($jwt, $key, array('HS256'));
 
 print_r($decoded);


### PR DESCRIPTION
Documentation was unclear as to why an algorithm was not being passed to JWT::encode(), added comment to clarify.