### PR TITLE
JWT::decode: doc-comment for DomainException added

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -70,7 +70,8 @@ class JWT
      *
      * @return object The JWT's payload as a PHP object
      *
-     * @throws InvalidArgumentException     Provided JWT was empty
+     * @throws InvalidArgumentException     Provided key/key-array was empty
+     * @throws DomainException              Provided JWT is malformed
      * @throws UnexpectedValueException     Provided JWT was invalid
      * @throws SignatureInvalidException    Provided JWT was invalid because the signature verification failed
      * @throws BeforeValidException         Provided JWT is trying to be used before it's eligible as defined by 'nbf'


### PR DESCRIPTION
Adds previously undocumented `DomainException` to the throws list in the doc-comment of the `JWT::decode` method.

This hotfixes the issue mentioned in #312 and #378.

See #312 for detailed info.