### PR TITLE
feat: add ed25519 support to JWK (public keys)

### DIFF
--- a/src/JWK.php
+++ b/src/JWK.php
@@ -161,7 +161,7 @@ class JWK
                     throw new UnexpectedValueException('x not set');
                 }
 
-                $publicKey = \base64_encode(JWT::urlsafeB64Decode($jwk['x']));
+                $publicKey = JWT::urlsafeToStandardB64($jwk['x']);
                 $alg = self::OKP_CURVES[$jwk['crv']];
                 return new Key($publicKey, $alg);
             default:

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -368,12 +368,25 @@ class JWT
      */
     public static function urlsafeB64Decode(string $input): string|false
     {
+        return \base64_decode(self::urlsafeToStandardB64($input));
+    }
+
+    /**
+     * Convert a string from URL-safe Base64 to standard Base64.
+     *
+     * @param string $input A Base64 encoded string with URL-safe characters (-_ and no padding)
+     *
+     * @return string A Base64 encoded string with standard characters (+/) and padding (=), when
+     * needed.
+     */
+    public static function urlsafeToStandardB64(string $input): string
+    {
         $remainder = \strlen($input) % 4;
         if ($remainder) {
             $padlen = 4 - $remainder;
             $input .= \str_repeat('=', $padlen);
         }
-        return \base64_decode(\strtr($input, '-_', '+/'));
+        return \strtr($input, '-_', '+/');
     }
 
     /**

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -198,7 +198,7 @@ class JWT
      *
      * @param string $msg  The message to sign
      * @param string|OpenSSLAsymmetricKey|OpenSSLCertificate|array<mixed>  $key  The secret key.
-     * @param string $alg  Supported algorithms are 'ES384','ES256', 'HS256', 'HS384',
+     * @param string $alg  Supported algorithms are 'EdDSA', 'ES384', 'ES256', 'HS256', 'HS384',
      *                    'HS512', 'RS256', 'RS384', and 'RS512'
      *
      * @return string An encrypted message
@@ -258,7 +258,7 @@ class JWT
      *
      * @param string $msg         The original message (header and body)
      * @param string $signature   The original signature
-     * @param string|OpenSSLAsymmetricKey|OpenSSLCertificate|array<mixed>  $keyMaterial For HS*, a string key works. for RS*, must be an instance of OpenSSLAsymmetricKey
+     * @param string|OpenSSLAsymmetricKey|OpenSSLCertificate|array<mixed>  $keyMaterial For Ed*, ES*, HS*, a string key works. for RS*, must be an instance of OpenSSLAsymmetricKey
      * @param string $alg         The algorithm
      *
      * @return bool

--- a/tests/JWKTest.php
+++ b/tests/JWKTest.php
@@ -139,6 +139,7 @@ class JWKTest extends TestCase
         return [
             ['rsa1-private.pem', 'rsa-jwkset.json', 'RS256'],
             ['ecdsa256-private.pem', 'ec-jwkset.json', 'ES256'],
+            ['ed25519-1.sec', 'ed25519-jwkset.json', 'EdDSA'],
         ];
     }
 

--- a/tests/data/ed25519-jwkset.json
+++ b/tests/data/ed25519-jwkset.json
@@ -1,0 +1,10 @@
+{
+    "keys": [
+        {
+            "kid": "jwk1",
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": "uOSJMhbKSG4V5xUHS7B9YHmVg_1yVd-G-Io6oBFhSfY"
+        }
+    ]
+}


### PR DESCRIPTION
This PR builds on https://github.com/firebase/php-jwt/pull/399 to support parsing JWK ed25519 keys.

* The base branch is temporarily set to #399 — I see this PR as a complement to that one. Please let me know if this should be done in any other way.

Reference documentation: [RFC8037](https://datatracker.ietf.org/doc/html/rfc8037)