### PR TITLE
feat: Decode jwt by provide public key as string

### DIFF
--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -321,6 +321,21 @@ class JWTTest extends TestCase
         $this->assertEquals($decoded, $expected);
     }
 
+    public function testDecodeWithoutKid()
+    {
+        $privateKeyFile = __DIR__ . '/data/ecdsa-private.pem';
+        $publicKeyFile = __DIR__ . '/data/ecdsa-public.pem';
+        $privateKey = file_get_contents($privateKeyFile);
+        $payload = ['foo' => 'bar'];
+        $encoded = JWT::encode($payload, $privateKey, 'ES256');
+
+        // Verify decoding succeeds
+        $publicKey = file_get_contents($publicKeyFile);
+        $decoded = JWT::decode($encoded, $publicKey);
+
+        $this->assertEquals('bar', $decoded->foo);
+    }
+
     /**
      * @runInSeparateProcess
      * @dataProvider provideEncodeDecode


### PR DESCRIPTION
There was a backward compatibility break from v5.5.1 to v6.0.0 at `JWT::decode()` with the 2nd argument that can not be a string or resource anymore. This pull request fixes it.