### PR TITLE
Add missing doc block for $alg in JWT::encode()

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -167,6 +167,8 @@ class JWT
      *
      * @param array<mixed>          $payload PHP array
      * @param string|resource|OpenSSLAsymmetricKey|OpenSSLCertificate $key The secret key.
+     * @param string                $alg     Supported algorithms are 'ES384','ES256', 'HS256', 'HS384',
+     *                                       'HS512', 'RS256', 'RS384', and 'RS512'
      * @param string                $keyId
      * @param array<string, string> $head    An array with header elements to attach
      *


### PR DESCRIPTION
The param $alg is missing on the php doc block for method encode() in class JWT (It ain't much but it's honest work)