### PR TITLE
Revert "fix: add flag to force object"

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -111,6 +111,10 @@ class JWT
         if (null === ($payload = static::jsonDecode($payloadRaw))) {
             throw new UnexpectedValueException('Invalid claims encoding');
         }
+        if (is_array($payload)) {
+            // prevent PHP Fatal Error in edge-cases when payload is empty array
+            $payload = (object) $payload;
+        }
         if (!$payload instanceof stdClass) {
             throw new UnexpectedValueException('Payload must be a JSON object');
         }
@@ -159,11 +163,6 @@ class JWT
             throw new ExpiredException('Expired token');
         }
         
-        if (is_array($payload)) {
-            // prevent PHP Fatal Error in edge-cases when payload is empty array
-            return (object) $payload;
-        }
-
         return $payload;
     }
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -158,6 +158,11 @@ class JWT
         if (isset($payload->exp) && ($timestamp - static::$leeway) >= $payload->exp) {
             throw new ExpiredException('Expired token');
         }
+        
+        if (is_array($payload)) {
+            // prevent PHP Fatal Error in edge-cases when payload is empty array
+            return (object) $payload;
+        }
 
         return $payload;
     }

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -162,7 +162,7 @@ class JWT
         if (isset($payload->exp) && ($timestamp - static::$leeway) >= $payload->exp) {
             throw new ExpiredException('Expired token');
         }
-        
+
         return $payload;
     }
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -355,7 +355,7 @@ class JWT
     public static function jsonEncode(array $input): string
     {
         if (PHP_VERSION_ID >= 50400) {
-            $json = \json_encode($input, \JSON_UNESCAPED_SLASHES|\JSON_FORCE_OBJECT);
+            $json = \json_encode($input, \JSON_UNESCAPED_SLASHES);
         } else {
             // PHP 5.3 only
             $json = \json_encode($input);

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -330,6 +330,15 @@ class JWTTest extends TestCase
         $this->assertEquals((object) $payload, $decoded);
     }
 
+    public function testDecodesArraysInJWTAsArray()
+    {
+        $key = 'yma6Hq4XQegCVND8ef23OYgxSrC3IKqk';
+        $payload = ['foo' => [1,2,3]];
+        $jwt = JWT::encode($payload, $key, 'HS256');
+        $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
+        $this->assertEquals($payload['foo'], $decoded['foo']);
+    }
+
     /**
      * @runInSeparateProcess
      * @dataProvider provideEncodeDecode

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -321,15 +321,6 @@ class JWTTest extends TestCase
         $this->assertEquals($decoded, $expected);
     }
 
-    public function testDecodesEmptyArrayAsObject()
-    {
-        $key = 'yma6Hq4XQegCVND8ef23OYgxSrC3IKqk';
-        $payload = [];
-        $jwt = JWT::encode($payload, $key, 'HS256');
-        $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
-        $this->assertEquals((object) $payload, $decoded);
-    }
-
     /**
      * @runInSeparateProcess
      * @dataProvider provideEncodeDecode

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -37,7 +37,7 @@ class JWTTest extends TestCase
         $this->expectException(ExpiredException::class);
         $payload = [
             "message" => "abc",
-            "exp" => time() - 20]; // time in the past
+            "exp" => time() -E 20]; // time in the past
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         JWT::decode($encoded, new Key('my_key', 'HS256'));
     }
@@ -263,15 +263,6 @@ class JWTTest extends TestCase
         $this->assertEquals(JWT::decode($msg, new Key('my_key', 'HS256')), $expected);
     }
 
-    public function testDecodesEmptyArrayAsObject()
-    {
-        $key = 'yma6Hq4XQegCVND8ef23OYgxSrC3IKqk';
-        $payload = [];
-        $jwt = JWT::encode($payload, $key, 'HS256');
-        $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
-        $this->assertEquals((object) $payload, $decoded);
-    }
-
     public function testRSEncodeDecode()
     {
         $privKey = openssl_pkey_new(['digest_alg' => 'sha256',
@@ -328,6 +319,15 @@ class JWTTest extends TestCase
         $expected = new stdClass();
         $expected->message = 'abc';
         $this->assertEquals($decoded, $expected);
+    }
+
+    public function testDecodesEmptyArrayAsObject()
+    {
+        $key = 'yma6Hq4XQegCVND8ef23OYgxSrC3IKqk';
+        $payload = [];
+        $jwt = JWT::encode($payload, $key, 'HS256');
+        $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
+        $this->assertEquals((object) $payload, $decoded);
     }
 
     /**

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -37,7 +37,7 @@ class JWTTest extends TestCase
         $this->expectException(ExpiredException::class);
         $payload = [
             "message" => "abc",
-            "exp" => time() -E 20]; // time in the past
+            "exp" => time() - 20]; // time in the past
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         JWT::decode($encoded, new Key('my_key', 'HS256'));
     }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -263,6 +263,15 @@ class JWTTest extends TestCase
         $this->assertEquals(JWT::decode($msg, new Key('my_key', 'HS256')), $expected);
     }
 
+    public function testDecodesEmptyArrayAsObject()
+    {
+        $key = 'yma6Hq4XQegCVND8ef23OYgxSrC3IKqk';
+        $payload = [];
+        $jwt = JWT::encode($payload, $key, 'HS256');
+        $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
+        $this->assertEquals((object) $payload, $decoded);
+    }
+
     public function testRSEncodeDecode()
     {
         $privKey = openssl_pkey_new(['digest_alg' => 'sha256',

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -336,7 +336,7 @@ class JWTTest extends TestCase
         $payload = ['foo' => [1,2,3]];
         $jwt = JWT::encode($payload, $key, 'HS256');
         $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
-        $this->assertEquals($payload['foo'], $decoded['foo']);
+        $this->assertEquals($payload['foo'], $decoded->foo);
     }
 
     /**


### PR DESCRIPTION
Reverts firebase/php-jwt#416

The change broke existing code that wasn't expecting the payload to be converted to object form... final JWT payload should be able to contain arrays