### PR TITLE
Fix style for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Example
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
 
-$key = "example_key";
-$payload = array(
-    "iss" => "http://example.org",
-    "aud" => "http://example.com",
-    "iat" => 1356999524,
-    "nbf" => 1357000000
-);
+$key = 'example_key';
+$payload = [
+    'iss' => 'http://example.org',
+    'aud' => 'http://example.com',
+    'iat' => 1356999524,
+    'nbf' => 1357000000
+];
 
 /**
  * IMPORTANT:
@@ -98,12 +98,12 @@ ehde/zUxo6UvS7UrBQIDAQAB
 -----END PUBLIC KEY-----
 EOD;
 
-$payload = array(
-    "iss" => "example.org",
-    "aud" => "example.com",
-    "iat" => 1356999524,
-    "nbf" => 1357000000
-);
+$payload = [
+    'iss' => 'example.org',
+    'aud' => 'example.com',
+    'iat' => 1356999524,
+    'nbf' => 1357000000
+];
 
 $jwt = JWT::encode($payload, $privateKey, 'RS256');
 echo "Encode:\n" . print_r($jwt, true) . "\n";
@@ -139,12 +139,12 @@ $privateKey = openssl_pkey_get_private(
     $passphrase
 );
 
-$payload = array(
-    "iss" => "example.org",
-    "aud" => "example.com",
-    "iat" => 1356999524,
-    "nbf" => 1357000000
-);
+$payload = [
+    'iss' => 'example.org',
+    'aud' => 'example.com',
+    'iat' => 1356999524,
+    'nbf' => 1357000000
+];
 
 $jwt = JWT::encode($payload, $privateKey, 'RS256');
 echo "Encode:\n" . print_r($jwt, true) . "\n";
@@ -173,12 +173,12 @@ $privateKey = base64_encode(sodium_crypto_sign_secretkey($keyPair));
 
 $publicKey = base64_encode(sodium_crypto_sign_publickey($keyPair));
 
-$payload = array(
-    "iss" => "example.org",
-    "aud" => "example.com",
-    "iat" => 1356999524,
-    "nbf" => 1357000000
-);
+$payload = [
+    'iss' => 'example.org',
+    'aud' => 'example.com',
+    'iat' => 1356999524,
+    'nbf' => 1357000000
+];
 
 $jwt = JWT::encode($payload, $privateKey, 'EdDSA');
 echo "Encode:\n" . print_r($jwt, true) . "\n";

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -237,7 +237,7 @@ class JWT
                 $signature = '';
                 $success = \openssl_sign($msg, $signature, $key, $algorithm); // @phpstan-ignore-line
                 if (!$success) {
-                    throw new DomainException("OpenSSL unable to sign data");
+                    throw new DomainException('OpenSSL unable to sign data');
                 }
                 if ($alg === 'ES256') {
                     $signature = self::signatureFromDER($signature, 256);

--- a/tests/JWKTest.php
+++ b/tests/JWKTest.php
@@ -125,7 +125,7 @@ class JWKTest extends TestCase
 
         $result = JWT::decode($msg, self::$keys);
 
-        $this->assertEquals("foo", $result->sub);
+        $this->assertEquals('foo', $result->sub);
     }
 
     /**
@@ -139,6 +139,6 @@ class JWKTest extends TestCase
 
         $result = JWT::decode($msg, self::$keys);
 
-        $this->assertEquals("bar", $result->sub);
+        $this->assertEquals('bar', $result->sub);
     }
 }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -36,8 +36,8 @@ class JWTTest extends TestCase
     {
         $this->expectException(ExpiredException::class);
         $payload = [
-            "message" => "abc",
-            "exp" => time() - 20]; // time in the past
+            'message' => 'abc',
+            'exp' => time() - 20]; // time in the past
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         JWT::decode($encoded, new Key('my_key', 'HS256'));
     }
@@ -46,7 +46,7 @@ class JWTTest extends TestCase
     {
         $this->expectException(BeforeValidException::class);
         $payload = [
-            "message" => "abc",
+            'message' => 'abc',
             "nbf" => time() + 20]; // time in the future
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         JWT::decode($encoded, new Key('my_key', 'HS256'));
@@ -56,7 +56,7 @@ class JWTTest extends TestCase
     {
         $this->expectException(BeforeValidException::class);
         $payload = [
-            "message" => "abc",
+            'message' => 'abc',
             "iat" => time() + 20]; // time in the future
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         JWT::decode($encoded, new Key('my_key', 'HS256'));
@@ -65,8 +65,8 @@ class JWTTest extends TestCase
     public function testValidToken()
     {
         $payload = [
-            "message" => "abc",
-            "exp" => time() + JWT::$leeway + 20]; // time in the future
+            'message' => 'abc',
+            'exp' => time() + JWT::$leeway + 20]; // time in the future
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
         $this->assertEquals($decoded->message, 'abc');
@@ -76,8 +76,8 @@ class JWTTest extends TestCase
     {
         JWT::$leeway = 60;
         $payload = [
-            "message" => "abc",
-            "exp" => time() - 20]; // time in the past
+            'message' => 'abc',
+            'exp' => time() - 20]; // time in the past
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
         $this->assertEquals($decoded->message, 'abc');
@@ -88,8 +88,8 @@ class JWTTest extends TestCase
     {
         JWT::$leeway = 60;
         $payload = [
-            "message" => "abc",
-            "exp" => time() - 70]; // time far in the past
+            'message' => 'abc',
+            'exp' => time() - 70]; // time far in the past
         $this->expectException(ExpiredException::class);
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
@@ -100,9 +100,9 @@ class JWTTest extends TestCase
     public function testValidTokenWithNbf()
     {
         $payload = [
-            "message" => "abc",
+            'message' => 'abc',
             "iat" => time(),
-            "exp" => time() + 20, // time in the future
+            'exp' => time() + 20, // time in the future
             "nbf" => time() - 20];
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
@@ -113,7 +113,7 @@ class JWTTest extends TestCase
     {
         JWT::$leeway = 60;
         $payload = [
-            "message" => "abc",
+            'message' => 'abc',
             "nbf"     => time() + 20]; // not before in near (leeway) future
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
@@ -125,7 +125,7 @@ class JWTTest extends TestCase
     {
         JWT::$leeway = 60;
         $payload = [
-            "message" => "abc",
+            'message' => 'abc',
             "nbf"     => time() + 65]; // not before too far in future
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $this->expectException(BeforeValidException::class);
@@ -137,7 +137,7 @@ class JWTTest extends TestCase
     {
         JWT::$leeway = 60;
         $payload = [
-            "message" => "abc",
+            'message' => 'abc',
             "iat"     => time() + 20]; // issued in near (leeway) future
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
@@ -149,7 +149,7 @@ class JWTTest extends TestCase
     {
         JWT::$leeway = 60;
         $payload = [
-            "message" => "abc",
+            'message' => 'abc',
             "iat"     => time() + 65]; // issued too far in future
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $this->expectException(BeforeValidException::class);
@@ -160,8 +160,8 @@ class JWTTest extends TestCase
     public function testInvalidToken()
     {
         $payload = [
-            "message" => "abc",
-            "exp" => time() + 20]; // time in the future
+            'message' => 'abc',
+            'exp' => time() + 20]; // time in the future
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $this->expectException(SignatureInvalidException::class);
         JWT::decode($encoded, new Key('my_key2', 'HS256'));
@@ -170,8 +170,8 @@ class JWTTest extends TestCase
     public function testNullKeyFails()
     {
         $payload = [
-            "message" => "abc",
-            "exp" => time() + JWT::$leeway + 20]; // time in the future
+            'message' => 'abc',
+            'exp' => time() + JWT::$leeway + 20]; // time in the future
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $this->expectException(TypeError::class);
         JWT::decode($encoded, new Key(null, 'HS256'));
@@ -180,8 +180,8 @@ class JWTTest extends TestCase
     public function testEmptyKeyFails()
     {
         $payload = [
-            "message" => "abc",
-            "exp" => time() + JWT::$leeway + 20]; // time in the future
+            'message' => 'abc',
+            'exp' => time() + JWT::$leeway + 20]; // time in the future
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $this->expectException(InvalidArgumentException::class);
         JWT::decode($encoded, new Key('', 'HS256'));


### PR DESCRIPTION
This PR fixes two minor style inconsistencies:
 1. Short array syntax is used in the README (used in all code since https://github.com/firebase/php-jwt/pull/385)
 2. Single quotes are used for strings where possible (that seems to been the project standard)

Style aspects like this should preferably be enforced by code analysis tools (like `php-cs-fixer`).
