### PR TITLE
Added missing ArrayAccess-type for $keyOrKeyArray in decode()

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -68,11 +68,15 @@ class JWT
      * Decodes a JWT string into a PHP object.
      *
      * @param string                 $jwt            The JWT
-     * @param Key|array<string,Key> $keyOrKeyArray  The Key or associative array of key IDs (kid) to Key objects.
-     *                                               If the algorithm used is asymmetric, this is the public key
-     *                                               Each Key object contains an algorithm and matching key.
-     *                                               Supported algorithms are 'ES384','ES256', 'HS256', 'HS384',
-     *                                               'HS512', 'RS256', 'RS384', and 'RS512'
+     * @param Key|ArrayAccess<string,Key>|array<string,Key> $keyOrKeyArray  The Key or associative array of key IDs
+     *                                                                      (kid) to Key objects.
+     *                                                                      If the algorithm used is asymmetric, this is
+     *                                                                      the public key.
+     *                                                                      Each Key object contains an algorithm and
+     *                                                                      matching key.
+     *                                                                      Supported algorithms are 'ES384','ES256',
+     *                                                                      'HS256', 'HS384', 'HS512', 'RS256', 'RS384'
+     *                                                                      and 'RS512'.
      *
      * @return stdClass The JWT's payload as a PHP object
      *


### PR DESCRIPTION
Signed-off-by: Pascal Paulis <ppaulis@gmail.com>

This PR adds the missing type `ArrayAccess` to the docblock of the `decode()` method.

Following the code:
```php
$key = self::getKey($keyOrKeyArray, property_exists($header, 'kid') ? $header->kid : null);
```
`getKey()` already expects a `CachedKeySet` (that implements `ArrayAccess`).