### PR TITLE
feat: Fix a future depreciation.

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -136,7 +136,7 @@ class JWT
             // OpenSSL expects an ASN.1 DER sequence for ES256/ES384 signatures
             $sig = self::signatureToDER($sig);
         }
-        if (!self::verify("${headb64}.${bodyb64}", $sig, $key->getKeyMaterial(), $header->alg)) {
+        if (!self::verify("{$headb64}.{$bodyb64}", $sig, $key->getKeyMaterial(), $header->alg)) {
             throw new SignatureInvalidException('Signature verification failed');
         }
 


### PR DESCRIPTION
Hey guys!

In PHP 8.2, which will be released on November 24th of this year, ${var] will be deprecated. You can still use {$var}. The pull request makes this pre-fix without breaking compatibility with recent versions of PHP.