### PR TITLE
Allow overriding default headers

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -192,7 +192,7 @@ class JWT
             $header['kid'] = $keyId;
         }
         if (isset($head) && \is_array($head)) {
-            $header = \array_merge($head, $header);
+            $header = \array_merge($header, $head);
         }
         $segments = [];
         $segments[] = static::urlsafeB64Encode((string) static::jsonEncode($header));


### PR DESCRIPTION
The 'typ' and 'alg' headers are currently set by default, and cannot be overridden with the $head parameter. This change would still keep the default headers, but would allow developers to override it if they so choose.

One such use case would be to create a JWT of "typ": "passport", as per the stir/shaken requirements.