### PR TITLE
Add ext-sodium to improve suggest block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "php": "^7.1||^8.0"
     },
     "suggest": {
-        "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+        "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
+        "ext-sodium": "It can support EdDSA (Ed25519) signatures"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "suggest": {
         "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
-        "ext-sodium": "It can support EdDSA (Ed25519) signatures"
+        "ext-sodium": "Support EdDSA (Ed25519) signatures"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# Changed log

- Before `PHP 7.2` version is released, the `sodium` extension is not included in the core PHP extension, it can also add the `ext-sodium` extension in the suggest block to remind developers when using the `PHP 7.0` and `PHP 7.1` versions.