### PR TITLE
Using the assertSame to make assert equals strict

### DIFF
--- a/tests/CachedKeySetTest.php
+++ b/tests/CachedKeySetTest.php
@@ -93,7 +93,7 @@ class CachedKeySetTest extends TestCase
             $this->getMockEmptyCache()
         );
         $this->assertInstanceOf(Key::class, $cachedKeySet['foo']);
-        $this->assertEquals('foo', $cachedKeySet['foo']->getAlgorithm());
+        $this->assertSame('foo', $cachedKeySet['foo']->getAlgorithm());
     }
 
     public function testWithDefaultAlg()
@@ -108,7 +108,7 @@ class CachedKeySetTest extends TestCase
             'baz256'
         );
         $this->assertInstanceOf(Key::class, $cachedKeySet['baz']);
-        $this->assertEquals('baz256', $cachedKeySet['baz']->getAlgorithm());
+        $this->assertSame('baz256', $cachedKeySet['baz']->getAlgorithm());
     }
 
     public function testKeyIdIsCached()
@@ -132,7 +132,7 @@ class CachedKeySetTest extends TestCase
             $cache->reveal()
         );
         $this->assertInstanceOf(Key::class, $cachedKeySet['foo']);
-        $this->assertEquals('foo', $cachedKeySet['foo']->getAlgorithm());
+        $this->assertSame('foo', $cachedKeySet['foo']->getAlgorithm());
     }
 
     public function testCachedKeyIdRefresh()
@@ -165,10 +165,10 @@ class CachedKeySetTest extends TestCase
             $cache->reveal()
         );
         $this->assertInstanceOf(Key::class, $cachedKeySet['foo']);
-        $this->assertEquals('foo', $cachedKeySet['foo']->getAlgorithm());
+        $this->assertSame('foo', $cachedKeySet['foo']->getAlgorithm());
 
         $this->assertInstanceOf(Key::class, $cachedKeySet['bar']);
-        $this->assertEquals('bar', $cachedKeySet['bar']->getAlgorithm());
+        $this->assertSame('bar', $cachedKeySet['bar']->getAlgorithm());
     }
 
     public function testCacheItemWithExpiresAfter()
@@ -204,7 +204,7 @@ class CachedKeySetTest extends TestCase
             $expiresAfter
         );
         $this->assertInstanceOf(Key::class, $cachedKeySet['foo']);
-        $this->assertEquals('foo', $cachedKeySet['foo']->getAlgorithm());
+        $this->assertSame('foo', $cachedKeySet['foo']->getAlgorithm());
     }
 
     public function testJwtVerify()
@@ -233,7 +233,7 @@ class CachedKeySetTest extends TestCase
 
         $result = JWT::decode($msg, $cachedKeySet);
 
-        $this->assertEquals('foo', $result->sub);
+        $this->assertSame('foo', $result->sub);
     }
 
     public function testRateLimit()
@@ -290,7 +290,7 @@ class CachedKeySetTest extends TestCase
         $this->assertArrayHasKey($kid, $cachedKeySet);
         $key = $cachedKeySet[$kid];
         $this->assertInstanceOf(Key::class, $key);
-        $this->assertEquals($keys['keys'][0]['alg'], $key->getAlgorithm());
+        $this->assertSame($keys['keys'][0]['alg'], $key->getAlgorithm());
     }
 
     public function provideFullIntegration()

--- a/tests/JWKTest.php
+++ b/tests/JWKTest.php
@@ -67,7 +67,7 @@ class JWKTest extends TestCase
         unset($jwkSet['keys'][0]['alg']);
 
         $jwks = JWK::parseKeySet($jwkSet, 'foo');
-        $this->assertEquals('foo', $jwks['jwk1']->getAlgorithm());
+        $this->assertSame('foo', $jwks['jwk1']->getAlgorithm());
     }
 
     public function testParseKeyWithEmptyDValue()
@@ -143,7 +143,7 @@ class JWKTest extends TestCase
         $keys = JWK::parseKeySet($jwkSet);
         $result = JWT::decode($msg, $keys);
 
-        $this->assertEquals('foo', $result->sub);
+        $this->assertSame('foo', $result->sub);
     }
 
     public function provideDecodeByJwkKeySet()
@@ -165,6 +165,6 @@ class JWKTest extends TestCase
 
         $result = JWT::decode($msg, self::$keys);
 
-        $this->assertEquals('bar', $result->sub);
+        $this->assertSame('bar', $result->sub);
     }
 }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -73,7 +73,7 @@ class JWTTest extends TestCase
         ];
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
-        $this->assertEquals($decoded->message, 'abc');
+        $this->assertSame($decoded->message, 'abc');
     }
 
     public function testValidTokenWithLeeway()
@@ -85,7 +85,7 @@ class JWTTest extends TestCase
         ];
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
-        $this->assertEquals($decoded->message, 'abc');
+        $this->assertSame($decoded->message, 'abc');
         JWT::$leeway = 0;
     }
 
@@ -99,7 +99,7 @@ class JWTTest extends TestCase
         $this->expectException(ExpiredException::class);
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
-        $this->assertEquals($decoded->message, 'abc');
+        $this->assertSame($decoded->message, 'abc');
         JWT::$leeway = 0;
     }
 
@@ -113,7 +113,7 @@ class JWTTest extends TestCase
         ];
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
-        $this->assertEquals($decoded->message, 'abc');
+        $this->assertSame($decoded->message, 'abc');
     }
 
     public function testValidTokenWithNbfLeeway()
@@ -125,7 +125,7 @@ class JWTTest extends TestCase
         ];
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
-        $this->assertEquals($decoded->message, 'abc');
+        $this->assertSame($decoded->message, 'abc');
         JWT::$leeway = 0;
     }
 
@@ -151,7 +151,7 @@ class JWTTest extends TestCase
         ];
         $encoded = JWT::encode($payload, 'my_key', 'HS256');
         $decoded = JWT::decode($encoded, new Key('my_key', 'HS256'));
-        $this->assertEquals($decoded->message, 'abc');
+        $this->assertSame($decoded->message, 'abc');
         JWT::$leeway = 0;
     }
 
@@ -301,7 +301,7 @@ class JWTTest extends TestCase
 
         $pubKey = base64_encode(sodium_crypto_sign_publickey($keyPair));
         $decoded = JWT::decode($msg, new Key($pubKey, 'EdDSA'));
-        $this->assertEquals('bar', $decoded->foo);
+        $this->assertSame('bar', $decoded->foo);
     }
 
     public function testInvalidEdDsaEncodeDecode()
@@ -350,7 +350,7 @@ class JWTTest extends TestCase
         $payload = ['foo' => [1, 2, 3]];
         $jwt = JWT::encode($payload, $key, 'HS256');
         $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
-        $this->assertEquals($payload['foo'], $decoded->foo);
+        $this->assertSame($payload['foo'], $decoded->foo);
     }
 
     /**
@@ -367,7 +367,7 @@ class JWTTest extends TestCase
         $publicKey = file_get_contents($publicKeyFile);
         $decoded = JWT::decode($encoded, new Key($publicKey, $alg));
 
-        $this->assertEquals('bar', $decoded->foo);
+        $this->assertSame('bar', $decoded->foo);
     }
 
     public function provideEncodeDecode()
@@ -393,6 +393,6 @@ class JWTTest extends TestCase
         // Verify decoding succeeds
         $decoded = JWT::decode($encoded, new Key($resource, 'RS512'));
 
-        $this->assertEquals('bar', $decoded->foo);
+        $this->assertSame('bar', $decoded->foo);
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assert equals strict.