### PR TITLE
feat: improve caching by only decoding jwks when necessary

### DIFF
--- a/src/CachedKeySet.php
+++ b/src/CachedKeySet.php
@@ -9,6 +9,7 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use InvalidArgumentException;
 use RuntimeException;
 use UnexpectedValueException;
 
@@ -42,7 +43,7 @@ class CachedKeySet implements ArrayAccess
      */
     private $cacheItem;
     /**
-     * @var array<string, array>
+     * @var array<string, array<mixed>>
      */
     private $keySet;
     /**
@@ -131,6 +132,9 @@ class CachedKeySet implements ArrayAccess
         throw new LogicException('Method not implemented');
     }
 
+    /**
+     * @return array<mixed>
+     */
     private function formatJwksForCache(string $jwks): array
     {
         $jwks = json_decode($jwks, true);
@@ -162,7 +166,7 @@ class CachedKeySet implements ArrayAccess
                 $this->keySet = $item->get();
                 // If the cached item is a string, the JWKS response was cached (previous behavior).
                 // Parse this into expected format array<kid, jwk> instead.
-                if (is_string($this->keySet)) {
+                if (\is_string($this->keySet)) {
                     $this->keySet = $this->formatJwksForCache($this->keySet);
                 }
             }

--- a/src/CachedKeySet.php
+++ b/src/CachedKeySet.php
@@ -3,13 +3,13 @@
 namespace Firebase\JWT;
 
 use ArrayAccess;
+use InvalidArgumentException;
 use LogicException;
 use OutOfBoundsException;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
-use InvalidArgumentException;
 use RuntimeException;
 use UnexpectedValueException;
 

--- a/src/CachedKeySet.php
+++ b/src/CachedKeySet.php
@@ -160,7 +160,7 @@ class CachedKeySet implements ArrayAccess
             if ($item->isHit()) {
                 // item found! retrieve it
                 $this->keySet = $item->get();
-                // If the cached key was a string, it cached the JWKS response body as a string.
+                // If the cached item is a string, the JWKS response was cached (previous behavior).
                 // Parse this into expected format array<kid, jwk> instead.
                 if (is_string($this->keySet)) {
                     $this->keySet = $this->formatJwksForCache($this->keySet);

--- a/tests/CachedKeySetTest.php
+++ b/tests/CachedKeySetTest.php
@@ -274,12 +274,13 @@ class CachedKeySetTest extends TestCase
         $payload = ['sub' => 'foo', 'exp' => strtotime('+10 seconds')];
         $msg = JWT::encode($payload, $privKey1, 'RS256', 'jwk1');
 
+        // format the cached value to match the expected format
         $cachedJwks = [];
         $rsaKeySet = file_get_contents(__DIR__ . '/data/rsa-jwkset.json');
-        // format the cached value to match the expected format
-        foreach(json_decode($rsaKeySet, true)['keys'] as $k => $v) {
+        foreach (json_decode($rsaKeySet, true)['keys'] as $k => $v) {
             $cachedJwks[$v['kid']] = $v;
         }
+
         $cacheItem = $this->prophesize(CacheItemInterface::class);
         $cacheItem->isHit()
             ->willReturn(true);

--- a/tests/CachedKeySetTest.php
+++ b/tests/CachedKeySetTest.php
@@ -17,11 +17,12 @@ class CachedKeySetTest extends TestCase
     private $testJwksUri = 'https://jwk.uri';
     private $testJwksUriKey = 'jwkshttpsjwk.uri';
     private $testJwks1 = '{"keys": [{"kid":"foo","kty":"RSA","alg":"foo","n":"","e":""}]}';
+    private $testCachedJwks1 = ['foo' => ['kid' => 'foo', 'kty' => 'RSA', 'alg' => 'foo', 'n' => '', 'e' => '']];
     private $testJwks2 = '{"keys": [{"kid":"bar","kty":"RSA","alg":"bar","n":"","e":""}]}';
     private $testJwks3 = '{"keys": [{"kid":"baz","kty":"RSA","n":"","e":""}]}';
 
     private $googleRsaUri = 'https://www.googleapis.com/oauth2/v3/certs';
-    // private $googleEcUri = 'https://www.gstatic.com/iap/verify/public_key-jwk';
+    private $googleEcUri = 'https://www.gstatic.com/iap/verify/public_key-jwk';
 
     public function testEmptyUriThrowsException()
     {
@@ -117,7 +118,7 @@ class CachedKeySetTest extends TestCase
         $cacheItem->isHit()
             ->willReturn(true);
         $cacheItem->get()
-            ->willReturn($this->testJwks1);
+            ->willReturn($this->testCachedJwks1);
 
         $cache = $this->prophesize(CacheItemPoolInterface::class);
         $cache->getItem($this->testJwksUriKey)
@@ -136,6 +137,66 @@ class CachedKeySetTest extends TestCase
     }
 
     public function testCachedKeyIdRefresh()
+    {
+        $cacheItem = $this->prophesize(CacheItemInterface::class);
+        $cacheItem->isHit()
+            ->shouldBeCalledOnce()
+            ->willReturn(true);
+        $cacheItem->get()
+            ->shouldBeCalledOnce()
+            ->willReturn($this->testCachedJwks1);
+        $cacheItem->set(Argument::any())
+            ->shouldBeCalledOnce()
+            ->will(function () {
+                return $this;
+            });
+
+        $cache = $this->prophesize(CacheItemPoolInterface::class);
+        $cache->getItem($this->testJwksUriKey)
+            ->shouldBeCalledOnce()
+            ->willReturn($cacheItem->reveal());
+        $cache->save(Argument::any())
+            ->shouldBeCalledOnce()
+            ->willReturn(true);
+
+        $cachedKeySet = new CachedKeySet(
+            $this->testJwksUri,
+            $this->getMockHttpClient($this->testJwks2), // updated JWK
+            $this->getMockHttpFactory(),
+            $cache->reveal()
+        );
+        $this->assertInstanceOf(Key::class, $cachedKeySet['foo']);
+        $this->assertSame('foo', $cachedKeySet['foo']->getAlgorithm());
+
+        $this->assertInstanceOf(Key::class, $cachedKeySet['bar']);
+        $this->assertSame('bar', $cachedKeySet['bar']->getAlgorithm());
+    }
+
+    public function testKeyIdIsCachedFromPreviousFormat()
+    {
+        $cacheItem = $this->prophesize(CacheItemInterface::class);
+        $cacheItem->isHit()
+            ->willReturn(true);
+        $cacheItem->get()
+            ->willReturn($this->testJwks1);
+
+        $cache = $this->prophesize(CacheItemPoolInterface::class);
+        $cache->getItem($this->testJwksUriKey)
+            ->willReturn($cacheItem->reveal());
+        $cache->save(Argument::any())
+            ->willReturn(true);
+
+        $cachedKeySet = new CachedKeySet(
+            $this->testJwksUri,
+            $this->prophesize(ClientInterface::class)->reveal(),
+            $this->prophesize(RequestFactoryInterface::class)->reveal(),
+            $cache->reveal()
+        );
+        $this->assertInstanceOf(Key::class, $cachedKeySet['foo']);
+        $this->assertSame('foo', $cachedKeySet['foo']->getAlgorithm());
+    }
+
+    public function testCachedKeyIdRefreshFromPreviousFormat()
     {
         $cacheItem = $this->prophesize(CacheItemInterface::class);
         $cacheItem->isHit()
@@ -213,12 +274,17 @@ class CachedKeySetTest extends TestCase
         $payload = ['sub' => 'foo', 'exp' => strtotime('+10 seconds')];
         $msg = JWT::encode($payload, $privKey1, 'RS256', 'jwk1');
 
+        $cachedJwks = [];
+        $rsaKeySet = file_get_contents(__DIR__ . '/data/rsa-jwkset.json');
+        // format the cached value to match the expected format
+        foreach(json_decode($rsaKeySet, true)['keys'] as $k => $v) {
+            $cachedJwks[$v['kid']] = $v;
+        }
         $cacheItem = $this->prophesize(CacheItemInterface::class);
         $cacheItem->isHit()
             ->willReturn(true);
         $cacheItem->get()
-            ->willReturn(file_get_contents(__DIR__ . '/data/rsa-jwkset.json')
-            );
+            ->willReturn($cachedJwks);
 
         $cache = $this->prophesize(CacheItemPoolInterface::class);
         $cache->getItem($this->testJwksUriKey)
@@ -297,7 +363,7 @@ class CachedKeySetTest extends TestCase
     {
         return [
             [$this->googleRsaUri],
-            // [$this->googleEcUri, 'LYyP2g']
+            [$this->googleEcUri, 'LYyP2g']
         ];
     }
 


### PR DESCRIPTION
addresses #481 

Calls `JWK::parseKey` on the matching key instead of calling `JWK::parseKeySet` on the whole response