### PR TITLE
fix: only check iat if nbf is not used

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -152,7 +152,7 @@ class JWT
         // Check that this token has been created before 'now'. This prevents
         // using tokens that have been created for later use (and haven't
         // correctly used the nbf claim).
-        if (isset($payload->iat) && $payload->iat > ($timestamp + static::$leeway)) {
+        if (!isset($payload->nbf) && isset($payload->iat) && $payload->iat > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
                 'Cannot handle token prior to ' . \date(DateTime::ISO8601, $payload->iat)
             );


### PR DESCRIPTION
See #475 
> and haven't correctly used the nbf claim

I interpret it as having no nbf claim set. So it was always intended as a fallback.