### PR TITLE
Added fix for the import docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Example encode/decode headers
 Decoding the JWT headers without verifying the JWT first is NOT recommended, and is not supported by
 this library. This is because without verifying the JWT, the header values could have been tampered with.
 Any value pulled from an unverified header should be treated as if it could be any string sent in from an
-attacker.  If this is something you still want to do in your application for whatever reason, it's possible to 
-decode the header values manually simply by calling `json_decode` and `base64_decode` on the JWT 
+attacker.  If this is something you still want to do in your application for whatever reason, it's possible to
+decode the header values manually simply by calling `json_decode` and `base64_decode` on the JWT
 header part:
 ```php
 use Firebase\JWT\JWT;
@@ -373,6 +373,8 @@ All exceptions in the `Firebase\JWT` namespace extend `UnexpectedValueException`
 like this:
 
 ```php
+use Firebase\JWT\JWT;
+use UnexpectedValueException;
 try {
     $decoded = JWT::decode($payload, $keys);
 } catch (LogicException $e) {


### PR DESCRIPTION
Under the section: https://github.com/firebase/php-jwt#exception-handling

```php
try {
    $decoded = JWT::decode($payload, $keys);
} catch (LogicException $e) {
    // errors having to do with environmental setup or malformed JWT Keys
} catch (UnexpectedValueException $e) {
    // errors having to do with JWT signature and claims
}
```

Added imports to this section.