### PR TITLE
Allow psr/cache ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "guzzlehttp/guzzle": "^6.5||^7.4",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
-        "psr/cache": "^1.0||^2.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0"
     }


### PR DESCRIPTION
There is a breaking change (added return types) but that doesn't impact this library because it doesn't implement the interfaces.