### PR TITLE
fix: use ATOM instead of ISO8601 in exception message

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -154,7 +154,7 @@ class JWT
         // token can actually be used. If it's not yet that time, abort.
         if (isset($payload->nbf) && floor($payload->nbf) > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
-                'Cannot handle token with nbf prior to ' . \date(DateTime::ISO8601, (int) $payload->nbf)
+                'Cannot handle token with nbf prior to ' . \date(DateTime::ATOM, (int) $payload->nbf)
             );
         }
 
@@ -163,7 +163,7 @@ class JWT
         // correctly used the nbf claim).
         if (!isset($payload->nbf) && isset($payload->iat) && floor($payload->iat) > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
-                'Cannot handle token with iat prior to ' . \date(DateTime::ISO8601, (int) $payload->iat)
+                'Cannot handle token with iat prior to ' . \date(DateTime::ATOM, (int) $payload->iat)
             );
         }
 


### PR DESCRIPTION
DateTime::ISO8601 has been deprecated since PHP 7.2