### PR TITLE
fix: update error text for consistency

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -154,7 +154,7 @@ class JWT
         // token can actually be used. If it's not yet that time, abort.
         if (isset($payload->nbf) && floor($payload->nbf) > ($timestamp + static::$leeway)) {
             $ex = new BeforeValidException(
-                'Cannot handle token with nbf prior to ' . \date(DateTime::ISO8601, floor($payload->nbf))
+                'Cannot handle token with nbf prior to ' . \date(DateTime::ISO8601, (int) floor($payload->nbf))
             );
             $ex->setPayload($payload);
             throw $ex;
@@ -165,7 +165,7 @@ class JWT
         // correctly used the nbf claim).
         if (!isset($payload->nbf) && isset($payload->iat) && floor($payload->iat) > ($timestamp + static::$leeway)) {
             $ex = new BeforeValidException(
-                'Cannot handle token with iat prior to ' . \date(DateTime::ISO8601, floor($payload->iat))
+                'Cannot handle token with iat prior to ' . \date(DateTime::ISO8601, (int) floor($payload->iat))
             );
             $ex->setPayload($payload);
             throw $ex;

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -154,7 +154,7 @@ class JWT
         // token can actually be used. If it's not yet that time, abort.
         if (isset($payload->nbf) && floor($payload->nbf) > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
-                'Cannot handle token with nbf prior to ' . \date(DateTime::ISO8601, (int) $payload->nbf)
+                'Cannot handle token with nbf prior to ' . \date(DateTime::ISO8601, floor($payload->nbf))
             );
         }
 
@@ -163,7 +163,7 @@ class JWT
         // correctly used the nbf claim).
         if (!isset($payload->nbf) && isset($payload->iat) && floor($payload->iat) > ($timestamp + static::$leeway)) {
             throw new BeforeValidException(
-                'Cannot handle token with iat prior to ' . \date(DateTime::ISO8601, (int) $payload->iat)
+                'Cannot handle token with iat prior to ' . \date(DateTime::ISO8601, floor($payload->iat))
             );
         }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/firebase/php-jwt/pull/492 where an inconsistency was introduced. When triggering these error messages, if the value should be rounded up, then the value in the error message won't match the value being checked. Given we're talking about fractions of a second, this shouldn't cause any real-world impact. This inconsistency may make debugging edge cases difficult, leading to confusion. This confusion may lead do setting too much leeway in timing settings.