### PR TITLE
chore(ci): add php 8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ "7.4", "8.0", "8.1", "8.2" ]
+        php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
     name: PHP ${{matrix.php }} Unit Test
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.0"
+          php-version: "8.2"
       - name: Run Script
         run: |
           composer global require friendsofphp/php-cs-fixer
@@ -49,7 +49,7 @@ jobs:
     - name: Install PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.0'
+        php-version: '8.2'
     - name: Run Script
       run: |
         composer install


### PR DESCRIPTION
For the moment blocked by https://github.com/phpspec/prophecy/pull/608

We can add `--ignore-platform-reqs` to get around this, but for now we can wait for `phpspec/prophecy`.