### PR TITLE
fix: ensure ratelimit expiry is set every time

### DIFF
--- a/src/CachedKeySet.php
+++ b/src/CachedKeySet.php
@@ -212,16 +212,12 @@ class CachedKeySet implements ArrayAccess
         }
 
         $cacheItem = $this->cache->getItem($this->rateLimitCacheKey);
-<<<<<<< Updated upstream
-        if (!$cacheItem->isHit()) {
-            $cacheItem->expiresAfter(60); // # of calls are cached each minute
-=======
+
         if (!$cacheItem->isHit() || !is_array($cacheItemData = $cacheItem->get())) {
             $cacheItemData = [
                 'callsPerMinute' => 0,
                 'expiry' => new \DateTime('+60 seconds', new \DateTimeZone('UTC')),
             ];
->>>>>>> Stashed changes
         }
 
         if (++$cacheItemData['callsPerMinute'] > $this->maxCallsPerMinute) {

--- a/src/CachedKeySet.php
+++ b/src/CachedKeySet.php
@@ -213,7 +213,7 @@ class CachedKeySet implements ArrayAccess
 
         $cacheItem = $this->cache->getItem($this->rateLimitCacheKey);
 
-        if (!$cacheItem->isHit() || !is_array($cacheItemData = $cacheItem->get())) {
+        if (!$cacheItem->isHit() || !\is_array($cacheItemData = $cacheItem->get())) {
             $cacheItemData = [
                 'callsPerMinute' => 0,
                 'expiry' => new \DateTime('+60 seconds', new \DateTimeZone('UTC')),

--- a/src/CachedKeySet.php
+++ b/src/CachedKeySet.php
@@ -212,15 +212,24 @@ class CachedKeySet implements ArrayAccess
         }
 
         $cacheItem = $this->cache->getItem($this->rateLimitCacheKey);
+<<<<<<< Updated upstream
         if (!$cacheItem->isHit()) {
             $cacheItem->expiresAfter(60); // # of calls are cached each minute
+=======
+        if (!$cacheItem->isHit() || !is_array($cacheItemData = $cacheItem->get())) {
+            $cacheItemData = [
+                'callsPerMinute' => 0,
+                'expiry' => new \DateTime('+60 seconds', new \DateTimeZone('UTC')),
+            ];
+>>>>>>> Stashed changes
         }
 
-        $callsPerMinute = (int) $cacheItem->get();
-        if (++$callsPerMinute > $this->maxCallsPerMinute) {
+        if (++$cacheItemData['callsPerMinute'] > $this->maxCallsPerMinute) {
             return true;
         }
-        $cacheItem->set($callsPerMinute);
+
+        $cacheItem->set($cacheItemData);
+        $cacheItem->expiresAt($cacheItemData['expiry']);
         $this->cache->save($cacheItem);
         return false;
     }


### PR DESCRIPTION
fixes https://github.com/firebase/php-jwt/issues/543

Without setting the cached item expiry every time, the expiry is not persisted. In order to address this, we cache an array instead of an integer for the rate limit in the `CachedKeySet` class.