### PR TITLE
chore: drop support for PHP 7.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
+        php: [ "8.0", "8.1", "8.2", "8.3" ]
     name: PHP ${{matrix.php }} Unit Test
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Use composer to manage your dependencies and download PHP-JWT:
 composer require firebase/php-jwt
 ```
 
-Optionally, install the `paragonie/sodium_compat` package from composer if your
-php is < 7.2 or does not have libsodium installed:
+Optionally, install the `paragonie/sodium_compat` package from composer if you
+do not have libsodium installed:
 
 ```bash
 composer require paragonie/sodium_compat

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Use composer to manage your dependencies and download PHP-JWT:
 composer require firebase/php-jwt
 ```
 
-Optionally, install the `paragonie/sodium_compat` package from composer if you
-do not have libsodium installed:
+Optionally, install the `paragonie/sodium_compat` package from composer if your
+php env does not have libsodium installed:
 
 ```bash
 composer require paragonie/sodium_compat

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.4||^8.0"
+        "php": "^8.0"
     },
     "suggest": {
         "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
@@ -32,10 +32,10 @@
         }
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^6.5||^7.4",
+        "guzzlehttp/guzzle": "^7.4",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
-        "psr/cache": "^1.0||^2.0",
+        "psr/cache": "^2.0||^3.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0"
     }

--- a/tests/CachedKeySetTest.php
+++ b/tests/CachedKeySetTest.php
@@ -553,7 +553,7 @@ final class TestMemoryCacheItem implements CacheItemInterface
         return $this->key;
     }
 
-    public function get()
+    public function get(): mixed
     {
         return $this->isHit() ? $this->value : null;
     }
@@ -571,7 +571,7 @@ final class TestMemoryCacheItem implements CacheItemInterface
         return $this->currentTime()->getTimestamp() < $this->expiration->getTimestamp();
     }
 
-    public function set($value)
+    public function set(mixed $value): static
     {
         $this->isHit = true;
         $this->value = $value;
@@ -579,13 +579,13 @@ final class TestMemoryCacheItem implements CacheItemInterface
         return $this;
     }
 
-    public function expiresAt($expiration)
+    public function expiresAt($expiration): static
     {
         $this->expiration = $expiration;
         return $this;
     }
 
-    public function expiresAfter($time)
+    public function expiresAfter($time): static
     {
         $this->expiration = $this->currentTime()->add(new \DateInterval("PT{$time}S"));
         return $this;


### PR DESCRIPTION
Additionally:
 - drop support for `guzzlehttp/guzzle:v6`
 - drop support for `psr/cache:v1` and add support for `psr/cache:v3` (dev only)