### PR TITLE
fix: readme or documentation about decoding jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ $jwks = ['keys' => []];
 
 // JWK::parseKeySet($jwks) returns an associative array of **kid** to Firebase\JWT\Key
 // objects. Pass this as the second parameter to JWT::decode.
-JWT::decode($payload, JWK::parseKeySet($jwks));
+JWT::decode($jwt, JWK::parseKeySet($jwks));
 ```
 
 Using Cached Key Sets
@@ -349,7 +349,7 @@ use InvalidArgumentException;
 use UnexpectedValueException;
 
 try {
-    $decoded = JWT::decode($payload, $keys);
+    $decoded = JWT::decode($jwt, $keys);
 } catch (InvalidArgumentException $e) {
     // provided key/key-array is empty or malformed.
 } catch (DomainException $e) {
@@ -379,7 +379,7 @@ like this:
 use Firebase\JWT\JWT;
 use UnexpectedValueException;
 try {
-    $decoded = JWT::decode($payload, $keys);
+    $decoded = JWT::decode($jwt, $keys);
 } catch (LogicException $e) {
     // errors having to do with environmental setup or malformed JWT Keys
 } catch (UnexpectedValueException $e) {
@@ -394,7 +394,7 @@ instead, you can do the following:
 
 ```php
 // return type is stdClass
-$decoded = JWT::decode($payload, $keys);
+$decoded = JWT::decode($jwt, $keys);
 
 // cast to array
 $decoded = json_decode(json_encode($decoded), true);


### PR DESCRIPTION
fixing typo on Readme about JWT Decode parameter from `$payload` to `$jwt`.

before fixed: 
```php
JWT::decode($payload, $key);
```
after fixed: 
```php
JWT::decode($jwt, $key);
```