### PR TITLE
chore: Prepare towards PHP8.4 compatibility

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,6 +16,10 @@ return (new PhpCsFixer\Config())
         'native_function_invocation' => [
             'strict' => false
         ],
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/src/CachedKeySet.php
+++ b/src/CachedKeySet.php
@@ -80,9 +80,9 @@ class CachedKeySet implements ArrayAccess
         ClientInterface $httpClient,
         RequestFactoryInterface $httpFactory,
         CacheItemPoolInterface $cache,
-        int $expiresAfter = null,
+        ?int $expiresAfter = null,
         bool $rateLimit = false,
-        string $defaultAlg = null
+        ?string $defaultAlg = null
     ) {
         $this->jwksUri = $jwksUri;
         $this->httpClient = $httpClient;

--- a/src/CachedKeySet.php
+++ b/src/CachedKeySet.php
@@ -180,7 +180,7 @@ class CachedKeySet implements ArrayAccess
             $jwksResponse = $this->httpClient->sendRequest($request);
             if ($jwksResponse->getStatusCode() !== 200) {
                 throw new UnexpectedValueException(
-                    sprintf('HTTP Error: %d %s for URI "%s"',
+                    \sprintf('HTTP Error: %d %s for URI "%s"',
                         $jwksResponse->getStatusCode(),
                         $jwksResponse->getReasonPhrase(),
                         $this->jwksUri,

--- a/src/JWK.php
+++ b/src/JWK.php
@@ -52,7 +52,7 @@ class JWK
      *
      * @uses parseKey
      */
-    public static function parseKeySet(array $jwks, string $defaultAlg = null): array
+    public static function parseKeySet(array $jwks, ?string $defaultAlg = null): array
     {
         $keys = [];
 
@@ -93,7 +93,7 @@ class JWK
      *
      * @uses createPemFromModulusAndExponent
      */
-    public static function parseKey(array $jwk, string $defaultAlg = null): ?Key
+    public static function parseKey(array $jwk, ?string $defaultAlg = null): ?Key
     {
         if (empty($jwk)) {
             throw new InvalidArgumentException('JWK must not be empty');

--- a/src/JWK.php
+++ b/src/JWK.php
@@ -212,7 +212,7 @@ class JWK
                 )
             );
 
-        return sprintf(
+        return \sprintf(
             "-----BEGIN PUBLIC KEY-----\n%s\n-----END PUBLIC KEY-----\n",
             wordwrap(base64_encode($pem), 64, "\n", true)
         );

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -96,7 +96,7 @@ class JWT
     public static function decode(
         string $jwt,
         $keyOrKeyArray,
-        stdClass &$headers = null
+        ?stdClass &$headers = null
     ): stdClass {
         // Validate JWT
         $timestamp = \is_null(static::$timestamp) ? \time() : static::$timestamp;
@@ -200,8 +200,8 @@ class JWT
         array $payload,
         $key,
         string $alg,
-        string $keyId = null,
-        array $head = null
+        ?string $keyId = null,
+        ?array $head = null
     ): string {
         $header = ['typ' => 'JWT'];
         if (isset($head) && \is_array($head)) {


### PR DESCRIPTION
This pull-request contains three commits:

**[chore: fix latest php-cs-fixer findings](https://github.com/firebase/php-jwt/commit/8b0a51bf13ca77a131e8124aab9632a9f40b8734)**

This ensures clean cgl state using the current php-cs-fixer version and ruleset.

**[chore: Mitigate PHP8.4 deprecation warnings (#570)](https://github.com/firebase/php-jwt/commit/7c7f4bce5570f9f7f18906ce0082deb4b64f68ee)**

This change replaces implicitly nullable method arguments by making them explicitly nullable to mitigate PHP8.4 deprecation warnings.

**[chore: Enable php-cs-fixer rules to avoid implicitly nullable method arguments](https://github.com/firebase/php-jwt/commit/0df848cdcd548021309c541dbb370dae6763fbe1)**

This change enables two rules in the php-cs-fixer ruleset to guard against future implicitly method arguments and ensures to use the `?` nullable operator for nullable methods and properties.

Resolves: #570 