### PR TITLE
Fixed implicitly nullable parameter types deprecated in PHP 8.4

### DIFF
--- a/src/CachedKeySet.php
+++ b/src/CachedKeySet.php
@@ -80,9 +80,9 @@ class CachedKeySet implements ArrayAccess
         ClientInterface $httpClient,
         RequestFactoryInterface $httpFactory,
         CacheItemPoolInterface $cache,
-        int $expiresAfter = null,
+        ?int $expiresAfter = null,
         bool $rateLimit = false,
-        string $defaultAlg = null
+        ?string $defaultAlg = null
     ) {
         $this->jwksUri = $jwksUri;
         $this->httpClient = $httpClient;

--- a/src/JWK.php
+++ b/src/JWK.php
@@ -52,7 +52,7 @@ class JWK
      *
      * @uses parseKey
      */
-    public static function parseKeySet(array $jwks, string $defaultAlg = null): array
+    public static function parseKeySet(array $jwks, ?string $defaultAlg = null): array
     {
         $keys = [];
 
@@ -93,7 +93,7 @@ class JWK
      *
      * @uses createPemFromModulusAndExponent
      */
-    public static function parseKey(array $jwk, string $defaultAlg = null): ?Key
+    public static function parseKey(array $jwk, ?string $defaultAlg = null): ?Key
     {
         if (empty($jwk)) {
             throw new InvalidArgumentException('JWK must not be empty');

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -96,7 +96,7 @@ class JWT
     public static function decode(
         string $jwt,
         $keyOrKeyArray,
-        stdClass &$headers = null
+        ?stdClass &$headers = null
     ): stdClass {
         // Validate JWT
         $timestamp = \is_null(static::$timestamp) ? \time() : static::$timestamp;
@@ -200,8 +200,8 @@ class JWT
         array $payload,
         $key,
         string $alg,
-        string $keyId = null,
-        array $head = null
+        ?string $keyId = null,
+        ?array $head = null
     ): string {
         $header = ['typ' => 'JWT'];
         if (isset($head) && \is_array($head)) {


### PR DESCRIPTION
PHP 8.4 has deprecated implicitly nullable types. This PR fixes the issue. Tested with PHP 8.4 alpha 4.

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types