### PR TITLE
Allow JWT::decode to accept an empty string as a valid kid

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -465,17 +465,15 @@ class JWT
         $keyOrKeyArray,
         ?string $kid
     ): Key {
+
+        $kid = (string) $kid;
+
         if ($keyOrKeyArray instanceof Key) {
             return $keyOrKeyArray;
         }
 
-        if (empty($kid) && $kid !== '0') {
-            throw new UnexpectedValueException('"kid" empty, unable to lookup correct key');
-        }
-
-        if ($keyOrKeyArray instanceof CachedKeySet) {
-            // Skip "isset" check, as this will automatically refresh if not set
-            return $keyOrKeyArray[$kid];
+        if (!is_array($keyOrKeyArray) && !$keyOrKeyArray instanceof ArrayAccess) {
+            throw new UnexpectedValueException('Expecting a Key or an associative array of keys');
         }
 
         if (!isset($keyOrKeyArray[$kid])) {

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -327,6 +327,19 @@ class JWTTest extends TestCase
         $this->assertEquals($decoded, $expected);
     }
 
+    public function testArrayAccessKIDChooserWhenJWTHasNoKey()
+    {
+        $key = new Key('my_key0', 'HS256');
+        $keys = new ArrayObject([
+            '' => $key,
+        ]);
+        $msg = JWT::encode(['message' => 'abc'], $key->getKeyMaterial(), 'HS256');
+        $decoded = JWT::decode($msg, $keys);
+        $expected = new stdClass();
+        $expected->message = 'abc';
+        $this->assertEquals($decoded, $expected);
+    }
+
     public function testArrayAccessKIDChooser()
     {
         $keys = new ArrayObject([
@@ -381,6 +394,26 @@ class JWTTest extends TestCase
         $msg = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwibmFtZSI6ImZvbyJ9.Q4Kee9E8o0Xfo4ADXvYA8t7dN_X_bU9K5w6tXuiSjlUxx';
         $this->expectException(UnexpectedValueException::class);
         JWT::decode($msg, new Key('secret', 'HS256'));
+    }
+
+    public function testInvalideKeyOrKeyArray()
+    {
+        $key = 'yma6Hq4XQegCVND8ef23OYgxSrC3IKqk';
+        $payload = ['foo' => [1, 2, 3]];
+        $jwt = JWT::encode($payload, $key, 'HS256');
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Expecting a Key or an associative array of keys');
+        JWT::decode($jwt, 'SomeKeyNotAnArray');
+    }
+
+    public function testKeyNotInKeyOrKeyArray()
+    {
+        $key = 'yma6Hq4XQegCVND8ef23OYgxSrC3IKqk';
+        $payload = ['foo' => [1, 2, 3]];
+        $jwt = JWT::encode($payload, $key, 'HS256');
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('"kid" invalid, unable to lookup correct key');
+        JWT::decode($jwt, ['notrealkey' => 'SomeKeyNotAnArray']);
     }
 
     public function testHSEncodeDecode()


### PR DESCRIPTION
There are instances when using CachedKeySet where a key is returned with an empty string as the kid. This is a valid use case and should be allowed.

For example Teleport Proxy uses this pattern to allow for a default key.
```
{
    "keys": [
        {
            "kty": "RSA",
            "alg": "RS256",
            "n": "<redacted>",
            "e": "AQAB",
            "use": "sig",
            "kid": ""
        }
    ]
}
```
Newer versions of teleport also return:

```
{
    "keys": [
        {
            "kty": "RSA",
            "alg": "RS256",
            "n": "<same key redacted>",
            "e": "AQAB",
            "use": "sig",
            "kid": "<redacted kid>"
        },
        {
            "kty": "RSA",
            "alg": "RS256",
            "n": "<same key redacted>",
            "e": "AQAB",
            "use": "sig",
            "kid": ""
        }
    ]
}
```


The getKey method can be simplified, as well as refactored to follow the same pattern as the CachedKeySet class which casts null kids to an empty string.

This change also adds a test to ensure that an empty string kid is a valid kid.