### PR TITLE
fix: support php 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ "8.0", "8.1", "8.2", "8.3" ]
+        php: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
     name: PHP ${{matrix.php }} Unit Test
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adds PHP 8.4 to the CI matrix.

See #572 and #578

This is marked as `deps` so that release-please picks it up.

The previously added support for PHP 8.4 was done as `chore` and therefore not released.