### PR TITLE
Fix example to avoid fatal error

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ $decoded = JWT::decode($jwt, new Key($key, 'HS256'));
 print_r($decoded);
 
 // Pass a stdClass in as the third parameter to get the decoded header values
-$decoded = JWT::decode($jwt, new Key($key, 'HS256'), $headers = new stdClass());
+$headers = new stdClass();
+$decoded = JWT::decode($jwt, new Key($key, 'HS256'), $headers);
 print_r($headers);
 
 /*


### PR DESCRIPTION
With PHP 8.x, the first example b0rks:
```
PHP Fatal error:  Uncaught Error: Firebase\JWT\JWT::decode(): Argument #3 ($headers) could not be passed by reference in REDACTED.php:26
Stack trace:
#0 {main}
  thrown in REDACTED/test.php on line 26
```