### PR TITLE
Add `JWT::resetTime()` && `JWT::maxLeeway()` to simplify unit tests

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -446,6 +446,16 @@ class JWT
     }
 
     /**
+     * Set leeway to max. Useful for unit testing with fixtures.
+     *
+     * @return void
+     */
+    public static function maxLeeway(): void
+    {
+        static::$leeway = \PHP_INT_MAX;
+    }
+
+    /**
      * Reset leeway and timestamp to their initial values.
      *
      * @return void

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -445,6 +445,16 @@ class JWT
         return \str_replace('=', '', \strtr(\base64_encode($input), '+/', '-_'));
     }
 
+    /**
+     * Reset leeway and timestamp to their initial values.
+     *
+     * @return void
+     */
+    public static function resetTime(): void
+    {
+        static::$leeway = 0;
+        static::$timestamp = null;
+    }
 
     /**
      * Determine if an algorithm has been provided for each Key

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -12,6 +12,12 @@ use UnexpectedValueException;
 
 class JWTTest extends TestCase
 {
+    protected function tearDown()
+    {
+        parent::tearDown();
+        JWT::resetTime();
+    }
+    
     public function testUrlSafeCharacters()
     {
         $encoded = JWT::encode(['message' => 'f?'], 'a', 'HS256');

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -546,4 +546,29 @@ class JWTTest extends TestCase
         $this->assertEquals('my_key_id', $headers->kid, 'key param not overridden');
         $this->assertEquals('HS256', $headers->alg, 'alg param not overridden');
     }
+
+    public function testReset()
+    {
+        JWT::$leeway = 100;
+        JWT::$timestamp = 7000;
+
+        // Pre-conditions
+        $this->assertSame(100, JWT::$leeway);
+        $this->assertSame(7000, JWT::$timestamp);
+
+        JWT::resetTime();
+
+        $this->assertSame(0, JWT::$leeway);
+        $this->assertNull(JWT::$timestamp);
+    }
+
+    public function testMaxLeeway()
+    {
+        // Pre-condition
+        $this->assertSame(0, JWT::$leeway);
+
+        JWT::maxLeeway();
+
+        $this->assertSame(\PHP_INT_MAX, JWT::$leeway);
+    }
 }


### PR DESCRIPTION
When unit testing, we have fixtures for valid JWTs. In tests, we often have to setUp/tearDown where we re/set these values. This is designed to make that easier.