### PR TITLE
Allow a list of strings as header value in `JWT::encode()`

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -189,7 +189,7 @@ class JWT
      * @param string                $alg     Supported algorithms are 'ES384','ES256', 'ES256K', 'HS256',
      *                                       'HS384', 'HS512', 'RS256', 'RS384', and 'RS512'
      * @param string                $keyId
-     * @param array<string, string> $head    An array with header elements to attach
+     * @param array<string, string|list<string>> $head    An array with header elements to attach
      *
      * @return string A signed JWT
      *


### PR DESCRIPTION
Fixes https://github.com/firebase/php-jwt/issues/593

In our case we need to be able to set the `crit` claim for a third party webservice. Found more info about crit here: https://mojoauth.com/glossary/jwt-critical/