### PR TITLE
docs: allow array of strings in head param

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -189,7 +189,7 @@ class JWT
      * @param string                $alg     Supported algorithms are 'ES384','ES256', 'ES256K', 'HS256',
      *                                       'HS384', 'HS512', 'RS256', 'RS384', and 'RS512'
      * @param string                $keyId
-     * @param array<string, string> $head    An array with header elements to attach
+     * @param array<string, string|string[]> $head  An array with header elements to attach
      *
      * @return string A signed JWT
      *


### PR DESCRIPTION
See https://github.com/firebase/php-jwt/pull/595

Allows array of strings in header to satisfy `crit` claim. While this isn't an "official" JWT claim, I don't see harm in allowing `head` to accept a string array.