### PR TITLE
chore: move release please from app to github action

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,3 +1,0 @@
-releaseType: simple
-handleGHRelease: true
-primaryBranch: main 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: release-please
+on:
+  push:
+    branches:
+      - main
+permissions:
+  # Needed for Release Please to create and update files
+  contents: write
+  # Needed for Release Please to create Release PRs
+  pull-requests: write
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: simple


### PR DESCRIPTION
because Release Please github app is being deprecated, we need to run it from an action instead