### PR TITLE
Add key size validation

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -694,7 +694,7 @@ class JWT
      */
     private static function validateHmacKeyLength(string $key, string $algorithm): void
     {
-        $keyLength = strlen($key) * 8;
+        $keyLength = \strlen($key) * 8;
         $minKeyLength = (int)str_replace($algorithm, 'SHA', '');
         if ($keyLength < $minKeyLength) {
             throw new DomainException('Provided key is too short');
@@ -710,9 +710,15 @@ class JWT
      */
     private static function validateRsaKeyLength(OpenSSLAsymmetricKey|OpenSSLCertificate $key): void
     {
-        $keyDetails = openssl_pkey_get_details(openssl_pkey_get_private($key));
-        $keyLength = $keyDetails['bits'];
         $minKeyLength = 2048;
+        $keyLength = 0;
+        $privateKey = openssl_pkey_get_private($key);
+        if ($privateKey !== false) {
+            $keyDetails = openssl_pkey_get_details($privateKey);
+            if ($keyDetails !== false) {
+                $keyLength = $keyDetails['bits'];
+            }
+        }
         if ($keyLength < $minKeyLength) {
             throw new DomainException('Provided key is too short');
         }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -2,7 +2,6 @@
 
 namespace Firebase\JWT;
 
-use ArrayObject;
 use DomainException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
I added a key size validation to fix this [issue](https://github.com/firebase/php-jwt/issues/605). It currently covers HMAC and RSA keys as mentioned in the CVE issue. Some feedback on the implementation would be appreciated. If feedback is positive, I can also add some new test cases for the changes.