### PR TITLE
fix: remove resource support

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ $passphrase = '[YOUR_PASSPHRASE]';
 // Can be generated with "ssh-keygen -t rsa -m pem"
 $privateKeyFile = '/path/to/key-with-passphrase.pem';
 
-// Create a private key of type "resource"
+/** @var OpenSSLAsymmetricKey $privateKey */
 $privateKey = openssl_pkey_get_private(
     file_get_contents($privateKeyFile),
     $passphrase

--- a/src/Key.php
+++ b/src/Key.php
@@ -10,7 +10,7 @@ use TypeError;
 class Key
 {
     /**
-     * @param string|resource|OpenSSLAsymmetricKey|OpenSSLCertificate $keyMaterial
+     * @param string|OpenSSLAsymmetricKey|OpenSSLCertificate $keyMaterial
      * @param string $algorithm
      */
     public function __construct(
@@ -21,9 +21,8 @@ class Key
             !\is_string($keyMaterial)
             && !$keyMaterial instanceof OpenSSLAsymmetricKey
             && !$keyMaterial instanceof OpenSSLCertificate
-            && !\is_resource($keyMaterial)
         ) {
-            throw new TypeError('Key material must be a string, resource, or OpenSSLAsymmetricKey');
+            throw new TypeError('Key material must be a string, OpenSSLCertificate, or OpenSSLAsymmetricKey');
         }
 
         if (empty($keyMaterial)) {
@@ -46,7 +45,7 @@ class Key
     }
 
     /**
-     * @return string|resource|OpenSSLAsymmetricKey|OpenSSLCertificate
+     * @return string|OpenSSLAsymmetricKey|OpenSSLCertificate
      */
     public function getKeyMaterial()
     {

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -28,7 +28,6 @@ class JWTTest extends TestCase
 
     public function testMalformedUtf8StringsFail()
     {
-
         $this->expectException(DomainException::class);
         JWT::encode(['message' => pack('c', 128)], $this->hmacKey->getKeyMaterial(), 'HS256');
     }
@@ -531,17 +530,17 @@ class JWTTest extends TestCase
         ];
     }
 
-    public function testEncodeDecodeWithResource()
+    public function testEncodeDecodeWithOpenSSLAsymmetricKey()
     {
         $pem = file_get_contents(__DIR__ . '/data/rsa1-public.pub');
-        $resource = openssl_pkey_get_public($pem);
+        $keyMaterial = openssl_pkey_get_public($pem);
         $privateKey = file_get_contents(__DIR__ . '/data/rsa1-private.pem');
 
         $payload = ['foo' => 'bar'];
         $encoded = JWT::encode($payload, $privateKey, 'RS512');
 
         // Verify decoding succeeds
-        $decoded = JWT::decode($encoded, new Key($resource, 'RS512'));
+        $decoded = JWT::decode($encoded, new Key($keyMaterial, 'RS512'));
 
         $this->assertSame('bar', $decoded->foo);
     }


### PR DESCRIPTION
openssl in PHP 8.1 no longer uses type `resource`. AFAIK, no valid `resource` can be supplied to these functions, so they can be removed.

**NOTE**: This commit message merged incorrectly as `add key size validation` when it should have been what the PR title here is (`fix: remove resource support`)