### PR TITLE
fix: validate numeric type of iat, nbf and exp claims in encode

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -224,6 +224,15 @@ class JWT
         if ($keyId !== null) {
             $header['kid'] = $keyId;
         }
+        if (isset($payload['nbf']) && !\is_numeric($payload['nbf'])) {
+            throw new UnexpectedValueException('Payload nbf must be a number');
+        }
+        if (isset($payload['iat']) && !\is_numeric($payload['iat'])) {
+            throw new UnexpectedValueException('Payload iat must be a number');
+        }
+        if (isset($payload['exp']) && !\is_numeric($payload['exp'])) {
+            throw new UnexpectedValueException('Payload exp must be a number');
+        }
         $segments = [];
         $segments[] = static::urlsafeB64Encode((string) static::jsonEncode($header));
         $segments[] = static::urlsafeB64Encode((string) static::jsonEncode($payload));

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -609,6 +609,30 @@ class JWTTest extends TestCase
         JWT::decode($payload, $this->hmacKey);
     }
 
+    public function testEncodeThrowsWhenIatIsNotNumeric(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Payload iat must be a number');
+
+        JWT::encode(['iat' => 'not-an-int'], $this->hmacKey->getKeyMaterial(), 'HS256');
+    }
+
+    public function testEncodeThrowsWhenNbfIsNotNumeric(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Payload nbf must be a number');
+
+        JWT::encode(['nbf' => 'not-an-int'], $this->hmacKey->getKeyMaterial(), 'HS256');
+    }
+
+    public function testEncodeThrowsWhenExpIsNotNumeric(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Payload exp must be a number');
+
+        JWT::encode(['exp' => 'not-an-int'], $this->hmacKey->getKeyMaterial(), 'HS256');
+    }
+
     public function testRsaKeyLengthValidationThrowsException(): void
     {
         $this->expectException(DomainException::class);

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -633,6 +633,21 @@ class JWTTest extends TestCase
         JWT::encode(['exp' => 'not-an-int'], $this->hmacKey->getKeyMaterial(), 'HS256');
     }
 
+    public function testEncodeAcceptsNumericStringTimestamps(): void
+    {
+        $payload = [
+            'message' => 'abc',
+            'iat' => (string) time(),
+            'exp' => (string) (time() + 20),
+            'nbf' => (string) (time() - 20),
+        ];
+
+        $encoded = JWT::encode($payload, $this->hmacKey->getKeyMaterial(), 'HS256');
+        $decoded = JWT::decode($encoded, $this->hmacKey);
+
+        $this->assertSame('abc', $decoded->message);
+    }
+
     public function testRsaKeyLengthValidationThrowsException(): void
     {
         $this->expectException(DomainException::class);


### PR DESCRIPTION
The decode() path already rejected non-numeric iat/nbf/exp values, but encode() accepted any type and silently produced an invalid token. Add the same is_numeric guards in encode() and cover them with unit tests.

Closes #453 