### PR TITLE
chore: allow guzzlehttp/guzzle 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^7.4",
+        "guzzlehttp/guzzle": "^7.4||^8.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
         "psr/cache": "^2.0||^3.0",


### PR DESCRIPTION
This PR allows upgrade to the newly released Guzzle HTTP 8.0 version.